### PR TITLE
Added omron plugins

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,6 +5,7 @@
 The proposed development builds upon the [IgH EtherCAT Master](https://etherlab.org/en/ethercat/). Installation steps are summarized here:
 ```shell
 $ git clone https://gitlab.com/etherlab.org/ethercat.git
+$ cd ethercat
 $ git checkout stable-1.5
 ```
 ```shell

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,5 @@
 ## Installation
-***Required setup : Ubuntu 20.04 LTS***
+***Required setup : Ubuntu 22.04 LTS***
 
 ### 1. Installing EtherLab
 The proposed development builds upon the [IgH EtherCAT Master](https://etherlab.org/en/ethercat/). Installation steps are summarized here:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ $ sudo ln -s /usr/local/etherlab/bin/ethercat /usr/bin/
 $ sudo ln -s /usr/local/etherlab/etc/init.d/ethercat /etc/init.d/ethercat
 $ sudo mkdir -p /etc/sysconfig
 $ sudo cp /usr/local/etherlab/etc/sysconfig/ethercat /etc/sysconfig/ethercat
-$ sudo echo KERNEL==\"EtherCAT[0-9]*\", MODE=\"0664\", GROUP=\"ecusers\" > /etc/udev/rules.d/99-EtherCAT.rules
+$ sudo bash -c "echo KERNEL==\"EtherCAT[0-9]*\", MODE=\"0664\", GROUP=\"ecusers\" > /etc/udev/rules.d/99-EtherCAT.rules"
 
 $ sudo vi /etc/sysconfig/ethercat
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,7 @@ $ sudo make modules_install install
 $ sudo depmod
 $ sudo ln -s /usr/local/etherlab/bin/ethercat /usr/bin/
 $ sudo ln -s /usr/local/etherlab/etc/init.d/ethercat /etc/init.d/ethercat
+$ sudo mkdir -p /etc/sysconfig
 $ sudo cp /usr/local/etherlab/etc/sysconfig/ethercat /etc/sysconfig/ethercat
 $ sudo echo KERNEL==\"EtherCAT[0-9]*\", MODE=\"0664\", GROUP=\"ecusers\" > /etc/udev/rules.d/99-EtherCAT.rules
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,6 @@ $ cd ethercat
 $ git checkout stable-1.5
 ```
 ```shell
-$ cd ethercat
 $ ./bootstrap # to create the configure script, if downloaded from the repository
 
 $ ./configure --prefix=/usr/local/etherlab  --disable-8139too --enable-generic # Ethernet driver e1000e not supported for kernels 4.X

--- a/ethercat_plugins/available_plugins.md
+++ b/ethercat_plugins/available_plugins.md
@@ -53,3 +53,11 @@ The list of currently supported EtherCAT modules and the available parameters. A
     - parameters: `di.1..8` - requested digital input
 - **AMAX-5056**: Sink-type Digital Ouput Module, 8-channel digital output, 24 V DC, 0.3 A.
     - parameters: `do.1..8` - requested digital output
+    
+### Omron
+
+- **Omron_NX_ECC201_NX_ID5442**: Omron EtherCAT Coupler NX_ECC201 with Input module NX_ID5442.
+- **Omron_NX_ECC201_NX_OD5256**: Omron EtherCAT Coupler NX_ECC201 with Output module NX_OD5256.
+- **Omron_NX_ECC202_NX_ID5142_1**: Omron EtherCAT Coupler NX_ECC202 with Input module NX_ID5142_1.
+- **Omron_NX_ECC202_NX_OD5256**: Omron EtherCAT Coupler NX_ECC202 with Output module NX_OD5256.
+    

--- a/ethercat_plugins/ethercat_plugins.xml
+++ b/ethercat_plugins/ethercat_plugins.xml
@@ -44,4 +44,16 @@
   <class name="ethercat_plugins/Advantech_AMAX5056" type="ethercat_plugins::Advantech_AMAX5056" base_class_type="ethercat_interface::EcSlave">
     <description>EtherCAT Terminal, 8-channel digital output, 24 V DC</description>
   </class>
+  <class name="ethercat_plugins/Omron_NX_ECC201_NX_ID5442" type="ethercat_plugins::Omron_NX_ECC201_NX_ID5442" base_class_type="ethercat_interface::EcSlave">
+    <description>Omron NX ECC201 NX ID5442</description>
+  </class>
+  <class name="ethercat_plugins/Omron_NX_ECC201_NX_OD5256" type="ethercat_plugins::Omron_NX_ECC201_NX_OD5256" base_class_type="ethercat_interface::EcSlave">
+    <description>Omron NX ECC201 NX OD5256</description>
+  </class>
+  <class name="ethercat_plugins/Omron_NX_ECC202_NX_ID5142_1" type="ethercat_plugins::Omron_NX_ECC202_NX_ID5142_1" base_class_type="ethercat_interface::EcSlave">
+    <description>Omron NX ECC202 NX ID5142 1</description>
+  </class>
+  <class name="ethercat_plugins/Omron_NX_ECC202_NX_OD5256" type="ethercat_plugins::Omron_NX_ECC202_NX_OD5256" base_class_type="ethercat_interface::EcSlave">
+    <description>Omron NX ECC202 NX OD5256</description>
+  </class>
 </library>

--- a/ethercat_plugins/src/maxon_plugins/maxon_epos3.cpp
+++ b/ethercat_plugins/src/maxon_plugins/maxon_epos3.cpp
@@ -43,8 +43,8 @@ public:
                   mode_of_operation_display_ == MODE_CYCLIC_SYNC_POSITION ||
                   mode_of_operation_display_ == MODE_PROFILED_POSITION ||
                   mode_of_operation_display_ == MODE_INTERPOLATED_POSITION ))
-                    target_torque_ = command_interface_ptr_->at(cii_target_position);
-                EC_WRITE_S32(domain_address, target_torque_);
+                    target_position_ = command_interface_ptr_->at(cii_target_position);
+                EC_WRITE_S32(domain_address, target_position_);
                 break;
             case 2:
                 if(isTargetVelocityRequired && (

--- a/ethercat_plugins/src/omron_plugins/omron_nx_ecc201_nx_id5442.cpp
+++ b/ethercat_plugins/src/omron_plugins/omron_nx_ecc201_nx_id5442.cpp
@@ -1,0 +1,107 @@
+
+
+#include "ethercat_interface/ec_slave.hpp"
+#include "ethercat_plugins/commondefs.hpp"
+#include <iostream>
+
+namespace ethercat_plugins
+{
+
+class Omron_NX_ECC201_NX_ID5442 : public ethercat_interface::EcSlave
+{
+public:
+    Omron_NX_ECC201_NX_ID5442() : EcSlave(0x00000083, 0x00000083) {}
+    virtual ~Omron_NX_ECC201_NX_ID5442() {}
+    virtual void processData(size_t index, uint8_t* domain_address){
+	    uint16_t data = 0;
+        data = EC_READ_U16(domain_address);
+        bool digital_inputs_[16];
+        digital_inputs_[0] = ((data & 0b0000000000000001) != 0); // bit 0
+        digital_inputs_[1] = ((data & 0b0000000000000010) != 0); // bit 1
+        digital_inputs_[2] = ((data & 0b0000000000000100) != 0); // bit 2
+        digital_inputs_[3] = ((data & 0b0000000000001000) != 0); // bit 3
+        digital_inputs_[4] = ((data & 0b0000000000010000) != 0); // bit 4
+        digital_inputs_[5] = ((data & 0b0000000000100000) != 0); // bit 5
+        digital_inputs_[6] = ((data & 0b0000000001000000) != 0); // bit 6
+        digital_inputs_[7] = ((data & 0b0000000010000000) != 0); // bit 7
+        digital_inputs_[8] = ((data & 0b0000000100000000) != 0); // bit 8
+        digital_inputs_[9] = ((data & 0b0000001000000000) != 0); // bit 9
+        digital_inputs_[10] = ((data & 0b0000010000000000) != 0); // bit 10
+        digital_inputs_[11] = ((data & 0b0000100000000000) != 0); // bit 11
+        digital_inputs_[12] = ((data & 0b0001000000000000) != 0); // bit 12
+        digital_inputs_[13] = ((data & 0b0010000000000000) != 0); // bit 13
+        digital_inputs_[14] = ((data & 0b0100000000000000) != 0); // bit 14
+        digital_inputs_[15] = ((data & 0b1000000000000000) != 0); // bit 15
+
+        for(auto i=0ul;i<16;i++){
+            if(sii_di_[i] >= 0)
+                state_interface_ptr_->at(sii_di_[i]) = digital_inputs_[i];
+        }
+    }
+    virtual const ec_sync_info_t* syncs() { return &syncs_[0]; }
+    virtual size_t syncSize() {
+        return sizeof(syncs_)/sizeof(ec_sync_info_t);
+    }
+    virtual const ec_pdo_entry_info_t* channels() {
+        return channels_;
+    }
+    virtual void domains(DomainMap& domains) const {
+        domains = domains_;
+    }
+    virtual bool setupSlave(
+                std::unordered_map<std::string, std::string> slave_paramters,
+                std::vector<double> * state_interface,
+                std::vector<double> * command_interface){
+
+        state_interface_ptr_ = state_interface;
+        command_interface_ptr_ = command_interface;
+        paramters_ = slave_paramters;
+
+        for(auto index = 0ul; index < 16; index++){
+            if(paramters_.find("di."+std::to_string(index))!= paramters_.end()){
+                if(paramters_.find("state_interface/"+paramters_["di."+std::to_string(index)]) != paramters_.end())
+                    sii_di_[index] = std::stoi(paramters_["state_interface/"+paramters_["di."+std::to_string(index)]]);
+            }
+        }
+        return true;
+    }
+    
+private:
+    int sii_di_[16] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+    // digital write values
+    bool write_data_[16] = {false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false};
+
+    ec_pdo_entry_info_t channels_[6] = {
+        {0x7022, 0x01, 16},
+        {0x3003, 0x04, 128},
+        {0x3006, 0x04, 128},
+        {0x2002, 0x01, 8},
+        {0x0000, 0x00, 8}, /* Gap */
+        {0x6002, 0x01, 16},
+    };
+    ec_pdo_info_t pdos_[5] = {
+        {0x1604, 1, channels_ + 0},
+        {0x1bf8, 2, channels_ + 1},
+        {0x1bff, 1, channels_ + 3},
+        {0x1bf4, 1, channels_ + 4},
+        {0x1a00, 1, channels_ + 5},
+    };
+    ec_sync_info_t syncs_[5] = {
+        {0, EC_DIR_OUTPUT, 0, NULL, EC_WD_DISABLE},
+        {1, EC_DIR_INPUT, 0, NULL, EC_WD_DISABLE},
+        {2, EC_DIR_OUTPUT, 1, pdos_ + 0, EC_WD_DISABLE},
+        {3, EC_DIR_INPUT, 4, pdos_ + 1, EC_WD_DISABLE},
+        {0xff}
+    };
+    DomainMap domains_ = {
+        {0, {5} }
+    };
+
+
+};
+
+}  // namespace ethercat_plugins
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(ethercat_plugins::Omron_NX_ECC201_NX_ID5442, ethercat_interface::EcSlave)

--- a/ethercat_plugins/src/omron_plugins/omron_nx_ecc201_nx_od5256.cpp
+++ b/ethercat_plugins/src/omron_plugins/omron_nx_ecc201_nx_od5256.cpp
@@ -1,0 +1,102 @@
+
+#include "ethercat_interface/ec_slave.hpp"
+#include "ethercat_plugins/commondefs.hpp"
+#include <iostream>
+
+namespace ethercat_plugins
+{
+
+class Omron_NX_ECC201_NX_OD5256 : public ethercat_interface::EcSlave
+{
+public:
+    Omron_NX_ECC201_NX_OD5256() : EcSlave(0x00000083, 0x00000083) {}
+    virtual ~Omron_NX_ECC201_NX_OD5256() {}
+    virtual void processData(size_t index, uint8_t* domain_address){
+        uint16_t digital_out_;
+	    digital_out_ = 0;
+        for(auto i=0ul;i<16;i++){
+            if(cii_do_[i] >= 0){
+                if(!std::isnan(command_interface_ptr_->at(cii_do_[i]))){
+                    write_data_[i] = (command_interface_ptr_->at(cii_do_[i])) ? true : false;
+                    if(sii_do_[i] >= 0)
+                        state_interface_ptr_->at(sii_do_[i]) = command_interface_ptr_->at(cii_do_[i]);
+                }
+            }
+        }
+
+	    // bit masking to get individual input values
+        digital_out_ += ( write_data_[0] << 0 ); // bit 0
+        digital_out_ += ( write_data_[1] << 1 ); // bit 1
+        digital_out_ += ( write_data_[2] << 2 ); // bit 2
+        digital_out_ += ( write_data_[3] << 3 ); // bit 3
+        digital_out_ += ( write_data_[4] << 4 ); // bit 4
+        digital_out_ += ( write_data_[5] << 5 ); // bit 5
+        digital_out_ += ( write_data_[6] << 6 ); // bit 6
+        digital_out_ += ( write_data_[7] << 7 ); // bit 7
+        digital_out_ += ( write_data_[8] << 8 ); // bit 8
+        digital_out_ += ( write_data_[9] << 9 ); // bit 9
+        digital_out_ += ( write_data_[10] << 10 ); // bit 10
+        digital_out_ += ( write_data_[11] << 11 ); // bit 11
+        digital_out_ += ( write_data_[12] << 12 ); // bit 12
+        digital_out_ += ( write_data_[13] << 13 ); // bit 13
+        digital_out_ += ( write_data_[14] << 14 ); // bit 14
+        digital_out_ += ( write_data_[15] << 15 ); // bit 15
+
+	    EC_WRITE_U16(domain_address , digital_out_);
+    }
+    virtual const ec_sync_info_t* syncs() { return &syncs_[0]; }
+    virtual size_t syncSize() {
+        return sizeof(syncs_)/sizeof(ec_sync_info_t);
+    }
+    virtual const ec_pdo_entry_info_t* channels() {
+        return channels_;
+    }
+    virtual void domains(DomainMap& domains) const {
+        domains = domains_;
+    }
+    virtual bool setupSlave(
+                std::unordered_map<std::string, std::string> slave_paramters,
+                std::vector<double> * state_interface,
+                std::vector<double> * command_interface){
+
+        state_interface_ptr_ = state_interface;
+        command_interface_ptr_ = command_interface;
+        paramters_ = slave_paramters;
+
+        for(auto index = 0ul; index < 16; index++){
+            if(paramters_.find("do."+std::to_string(index))!= paramters_.end()){
+                if(paramters_.find("command_interface/"+paramters_["do."+std::to_string(index)]) != paramters_.end())
+                    cii_do_[index] = std::stoi(paramters_["command_interface/"+paramters_["do."+std::to_string(index)]]);
+                if(paramters_.find("state_interface/"+paramters_["do."+std::to_string(index)]) != paramters_.end())
+                    sii_do_[index] = std::stoi(paramters_["state_interface/"+paramters_["do."+std::to_string(index)]]);
+            }
+        }
+        return true;
+    }
+
+private:
+    int cii_do_[16] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+    int sii_do_[16] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+    // digital write values
+    bool write_data_[16] = {false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false};
+
+    ec_pdo_entry_info_t channels_[1] = {
+        {0x7022, 0x01, 16}, /* Output */
+    };
+    ec_pdo_info_t pdos_[1] = {
+        {0x1604, 1, channels_ + 0}, /* Channel 1 */
+    };
+    ec_sync_info_t syncs_[2] = {
+        {2, EC_DIR_OUTPUT, 1, pdos_ + 0, EC_WD_DISABLE},
+        {0xff}
+    };
+    DomainMap domains_ = {
+        {0, {0} }
+    };
+};
+
+}  // namespace ethercat_plugins
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(ethercat_plugins::Omron_NX_ECC201_NX_OD5256, ethercat_interface::EcSlave)

--- a/ethercat_plugins/src/omron_plugins/omron_nx_ecc202_nx_id5142_1.cpp
+++ b/ethercat_plugins/src/omron_plugins/omron_nx_ecc202_nx_id5142_1.cpp
@@ -1,0 +1,103 @@
+
+#include "ethercat_interface/ec_slave.hpp"
+#include "ethercat_plugins/commondefs.hpp"
+#include <iostream>
+
+namespace ethercat_plugins
+{
+
+class Omron_NX_ECC202_NX_ID5142_1 : public ethercat_interface::EcSlave
+{
+public:
+    Omron_NX_ECC202_NX_ID5142_1() : EcSlave(0x00000083, 0x000000a6) {}   // 0x01115142 for NX-ID5142-1 and 0x05115142 for NX-ID5142-5
+    virtual ~Omron_NX_ECC202_NX_ID5142_1() {}
+    virtual void processData(size_t index, uint8_t* domain_address){
+	    uint16_t data = 0;
+        data = EC_READ_U16(domain_address);
+        bool digital_inputs_[16];
+        digital_inputs_[0] = ((data & 0b0000000000000001) != 0); // bit 0
+        digital_inputs_[1] = ((data & 0b0000000000000010) != 0); // bit 1
+        digital_inputs_[2] = ((data & 0b0000000000000100) != 0); // bit 2
+        digital_inputs_[3] = ((data & 0b0000000000001000) != 0); // bit 3
+        digital_inputs_[4] = ((data & 0b0000000000010000) != 0); // bit 4
+        digital_inputs_[5] = ((data & 0b0000000000100000) != 0); // bit 5
+        digital_inputs_[6] = ((data & 0b0000000001000000) != 0); // bit 6
+        digital_inputs_[7] = ((data & 0b0000000010000000) != 0); // bit 7
+        digital_inputs_[8] = ((data & 0b0000000100000000) != 0); // bit 8
+        digital_inputs_[9] = ((data & 0b0000001000000000) != 0); // bit 9
+        digital_inputs_[10] = ((data & 0b0000010000000000) != 0); // bit 10
+        digital_inputs_[11] = ((data & 0b0000100000000000) != 0); // bit 11
+        digital_inputs_[12] = ((data & 0b0001000000000000) != 0); // bit 12
+        digital_inputs_[13] = ((data & 0b0010000000000000) != 0); // bit 13
+        digital_inputs_[14] = ((data & 0b0100000000000000) != 0); // bit 14
+        digital_inputs_[15] = ((data & 0b1000000000000000) != 0); // bit 15
+
+        for(auto i=0ul;i<16;i++){
+            if(sii_di_[i] >= 0)
+                state_interface_ptr_->at(sii_di_[i]) = digital_inputs_[i];
+        }
+    }
+    virtual const ec_sync_info_t* syncs() { return &syncs_[0]; }
+    virtual size_t syncSize() {
+        return sizeof(syncs_)/sizeof(ec_sync_info_t);
+    }
+    virtual const ec_pdo_entry_info_t* channels() {
+        return channels_;
+    }
+    virtual void domains(DomainMap& domains) const {
+        domains = domains_;
+    }
+    virtual bool setupSlave(
+                std::unordered_map<std::string, std::string> slave_paramters,
+                std::vector<double> * state_interface,
+                std::vector<double> * command_interface){
+
+        state_interface_ptr_ = state_interface;
+        command_interface_ptr_ = command_interface;
+        paramters_ = slave_paramters;
+
+        for(auto index = 0ul; index < 16; index++){
+            if(paramters_.find("di."+std::to_string(index))!= paramters_.end()){
+                if(paramters_.find("state_interface/"+paramters_["di."+std::to_string(index)]) != paramters_.end())
+                    sii_di_[index] = std::stoi(paramters_["state_interface/"+paramters_["di."+std::to_string(index)]]);
+            }
+        }
+        return true;
+    }
+    
+private:
+    int sii_di_[16] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+    // digital write values
+    bool write_data_[16] = {false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false};
+
+    ec_pdo_entry_info_t channels_[6] = {
+        {0x7022, 0x01, 16},
+        {0x3003, 0x04, 128},
+        {0x3006, 0x04, 128},
+        {0x2002, 0x01, 8},
+        {0x0000, 0x00, 8}, /* Gap */
+        {0x6002, 0x01, 16},
+    };
+    ec_pdo_info_t pdos_[5] = {
+        {0x1604, 1, channels_ + 0},
+        {0x1bf8, 2, channels_ + 1},
+        {0x1bff, 1, channels_ + 3},
+        {0x1bf4, 1, channels_ + 4},
+        {0x1a00, 1, channels_ + 5},
+    };
+    ec_sync_info_t syncs_[5] = {
+        {0, EC_DIR_OUTPUT, 0, NULL, EC_WD_DISABLE},
+        {1, EC_DIR_INPUT, 0, NULL, EC_WD_DISABLE},
+        {2, EC_DIR_OUTPUT, 1, pdos_ + 0, EC_WD_DISABLE},
+        {3, EC_DIR_INPUT, 4, pdos_ + 1, EC_WD_DISABLE},
+        {0xff}
+    };
+    DomainMap domains_ = {
+        {0, {5} }
+    };
+};
+}  // namespace ethercat_plugins
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(ethercat_plugins::Omron_NX_ECC202_NX_ID5142_1, ethercat_interface::EcSlave)

--- a/ethercat_plugins/src/omron_plugins/omron_nx_ecc202_nx_od5256.cpp
+++ b/ethercat_plugins/src/omron_plugins/omron_nx_ecc202_nx_od5256.cpp
@@ -1,0 +1,102 @@
+
+#include "ethercat_interface/ec_slave.hpp"
+#include "ethercat_plugins/commondefs.hpp"
+#include <iostream>
+
+namespace ethercat_plugins
+{
+
+class Omron_NX_ECC202_NX_OD5256 : public ethercat_interface::EcSlave
+{
+public:
+    Omron_NX_ECC202_NX_OD5256() : EcSlave(0x00000083, 0x000000a6) {}
+    virtual ~Omron_NX_ECC202_NX_OD5256() {}
+    virtual void processData(size_t index, uint8_t* domain_address){
+        uint16_t digital_out_;
+	    digital_out_ = 0;
+        for(auto i=0ul;i<16;i++){
+            if(cii_do_[i] >= 0){
+                if(!std::isnan(command_interface_ptr_->at(cii_do_[i]))){
+                    write_data_[i] = (command_interface_ptr_->at(cii_do_[i])) ? true : false;
+                    if(sii_do_[i] >= 0)
+                        state_interface_ptr_->at(sii_do_[i]) = command_interface_ptr_->at(cii_do_[i]);
+                }
+            }
+        }
+
+	    // bit masking to get individual input values
+        digital_out_ += ( write_data_[0] << 0 ); // bit 0
+        digital_out_ += ( write_data_[1] << 1 ); // bit 1
+        digital_out_ += ( write_data_[2] << 2 ); // bit 2
+        digital_out_ += ( write_data_[3] << 3 ); // bit 3
+        digital_out_ += ( write_data_[4] << 4 ); // bit 4
+        digital_out_ += ( write_data_[5] << 5 ); // bit 5
+        digital_out_ += ( write_data_[6] << 6 ); // bit 6
+        digital_out_ += ( write_data_[7] << 7 ); // bit 7
+        digital_out_ += ( write_data_[8] << 8 ); // bit 8
+        digital_out_ += ( write_data_[9] << 9 ); // bit 9
+        digital_out_ += ( write_data_[10] << 10 ); // bit 10
+        digital_out_ += ( write_data_[11] << 11 ); // bit 11
+        digital_out_ += ( write_data_[12] << 12 ); // bit 12
+        digital_out_ += ( write_data_[13] << 13 ); // bit 13
+        digital_out_ += ( write_data_[14] << 14 ); // bit 14
+        digital_out_ += ( write_data_[15] << 15 ); // bit 15
+
+	    EC_WRITE_U16(domain_address , digital_out_);
+    }
+    virtual const ec_sync_info_t* syncs() { return &syncs_[0]; }
+    virtual size_t syncSize() {
+        return sizeof(syncs_)/sizeof(ec_sync_info_t);
+    }
+    virtual const ec_pdo_entry_info_t* channels() {
+        return channels_;
+    }
+    virtual void domains(DomainMap& domains) const {
+        domains = domains_;
+    }
+    virtual bool setupSlave(
+                std::unordered_map<std::string, std::string> slave_paramters,
+                std::vector<double> * state_interface,
+                std::vector<double> * command_interface){
+
+        state_interface_ptr_ = state_interface;
+        command_interface_ptr_ = command_interface;
+        paramters_ = slave_paramters;
+
+        for(auto index = 0ul; index < 16; index++){
+            if(paramters_.find("do."+std::to_string(index))!= paramters_.end()){
+                if(paramters_.find("command_interface/"+paramters_["do."+std::to_string(index)]) != paramters_.end())
+                    cii_do_[index] = std::stoi(paramters_["command_interface/"+paramters_["do."+std::to_string(index)]]);
+                if(paramters_.find("state_interface/"+paramters_["do."+std::to_string(index)]) != paramters_.end())
+                    sii_do_[index] = std::stoi(paramters_["state_interface/"+paramters_["do."+std::to_string(index)]]);
+            }
+        }
+        return true;
+    }
+
+private:
+    int cii_do_[16] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+    int sii_do_[16] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+    // digital write values
+    bool write_data_[16] = {false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false};
+
+    ec_pdo_entry_info_t channels_[1] = {
+        {0x7022, 0x01, 16}, /* Output */
+    };
+    ec_pdo_info_t pdos_[1] = {
+        {0x1604, 1, channels_ + 0}, /* Channel 1 */
+    };
+    ec_sync_info_t syncs_[2] = {
+        {2, EC_DIR_OUTPUT, 1, pdos_ + 0, EC_WD_DISABLE},
+        {0xff}
+    };
+    DomainMap domains_ = {
+        {0, {0} }
+    };
+};
+
+}  // namespace ethercat_plugins
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(ethercat_plugins::Omron_NX_ECC202_NX_OD5256, ethercat_interface::EcSlave)


### PR DESCRIPTION
Added

- **Omron_NX_ECC201_NX_ID5442**: Omron EtherCAT Coupler NX_ECC201 with Input module NX_ID5442.
- **Omron_NX_ECC201_NX_OD5256**: Omron EtherCAT Coupler NX_ECC201 with Output module NX_OD5256.
- **Omron_NX_ECC202_NX_ID5142_1**: Omron EtherCAT Coupler NX_ECC202 with Input module NX_ID5142_1.
- **Omron_NX_ECC202_NX_OD5256**: Omron EtherCAT Coupler NX_ECC202 with Output module NX_OD5256.

Here coupler and input/output modules can't be separated like Beckhoff since running the **ethercat slaves** command shows only the coupler in case of omron. 