### PR TITLE
Refactored Maxon EPOS3 drive interfaces

### DIFF
--- a/ethercat_plugins/available_plugins.md
+++ b/ethercat_plugins/available_plugins.md
@@ -33,12 +33,6 @@ The list of currently supported EtherCAT modules and the available parameters. A
 - **EPOS3**: EPOS3 70/10 EtherCAT, digital positioning controller, 10 A, 11 - 70 VDC
     - parameters:
         1. `mode_of_operation`: see [EPOS3 documentation](https://maxonjapan.com/wp-content/uploads/manual/epos/EPOS3_EtherCAT_Firmware_Specification_En.pdf) -> Table 8-116
-        2. `motor_position`: current motor position
-        3. `motor_velocity`: current motor velocity
-        4. `motor_torque`: current motor torque
-        5. `target_position`: target motor position
-        6. `target_velocity`: target motor velocity
-        7. `target_torque`: target motor torque
 
 ## ATI
 - **ATI_FTSensor**: ATI EtherCAT F/T Sensor

--- a/ethercat_plugins/src/maxon_plugins/maxon_epos3.cpp
+++ b/ethercat_plugins/src/maxon_plugins/maxon_epos3.cpp
@@ -159,26 +159,26 @@ public:
         if(paramters_.find("mode_of_operation")!= paramters_.end())
             mode_of_operation_ = std::stod(paramters_["mode_of_operation"]);
 
-        isPositionRequired = paramters_.find("motor_position")!= paramters_.end();
-        isVelocityRequired = paramters_.find("motor_velocity")!= paramters_.end();
-        isTorqueRequired = paramters_.find("motor_torque")!= paramters_.end();
+        isPositionRequired = paramters_.find("state_interface/position")!= paramters_.end();
+        isVelocityRequired = paramters_.find("state_interface/velocity")!= paramters_.end();
+        isTorqueRequired = paramters_.find("state_interface/effort")!= paramters_.end();
 
-        isTargetPositionRequired = paramters_.find("target_position")!= paramters_.end();
-        isTargetVelocityRequired = paramters_.find("target_velocity")!= paramters_.end();
-        isTargetTorqueRequired = paramters_.find("target_torque")!= paramters_.end();
+        isTargetPositionRequired = paramters_.find("command_interface/position")!= paramters_.end();
+        isTargetVelocityRequired = paramters_.find("command_interface/velocity")!= paramters_.end();
+        isTargetTorqueRequired = paramters_.find("command_interface/effort")!= paramters_.end();
 
         if(isPositionRequired)
-            sii_position = std::stoi(paramters_["state_interface/"+paramters_["motor_position"]]);
+            sii_position = std::stoi(paramters_["state_interface/position"]);
         if(isVelocityRequired)
-            sii_velocity = std::stoi(paramters_["state_interface/"+paramters_["motor_velocity"]]);
+            sii_velocity = std::stoi(paramters_["state_interface/velocity"]);
         if(isTorqueRequired)
-            sii_torque = std::stoi(paramters_["state_interface/"+paramters_["motor_torque"]]);
+            sii_torque = std::stoi(paramters_["state_interface/effort"]);
         if(isTargetPositionRequired)
-            cii_target_position = std::stoi(paramters_["command_interface/"+paramters_["target_position"]]);
+            cii_target_position = std::stoi(paramters_["command_interface/position"]);
         if(isTargetVelocityRequired)
-            cii_target_velocity = std::stoi(paramters_["command_interface/"+paramters_["target_velocity"]]);
+            cii_target_velocity = std::stoi(paramters_["command_interface/velocity"]);
         if(isTargetTorqueRequired)
-            cii_target_torque = std::stoi(paramters_["command_interface/"+paramters_["target_torque"]]);
+            cii_target_torque = std::stoi(paramters_["command_interface/effort"]);
 
         return true;
     }


### PR DESCRIPTION
Maxon EPOS3 drive was using a non-efficient remapping system from `ros2_control` state and command interfaces to internal interfaces removed here. 
