### PR TITLE
Generic module for EtherCAT compatible cia402 drives

### DIFF
--- a/ethercat_interface/include/ethercat_interface/ec_slave.hpp
+++ b/ethercat_interface/include/ethercat_interface/ec_slave.hpp
@@ -58,8 +58,8 @@ public:
     paramters_ = slave_paramters;
     return true;
   }
-  const uint32_t vendor_id_;
-  const uint32_t product_id_;
+  uint32_t vendor_id_;
+  uint32_t product_id_;
 
 protected:
   std::vector<double> * state_interface_ptr_;

--- a/ethercat_plugins/CMakeLists.txt
+++ b/ethercat_plugins/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(ethercat_interface REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 file(GLOB_RECURSE PLUGINS_SRC src/*/*.cpp)
 add_library(ethercat_plugins ${PLUGINS_SRC})
@@ -22,6 +23,8 @@ ament_target_dependencies(
   "ethercat_interface"
   "pluginlib"
 )
+
+target_link_libraries(ethercat_plugins yaml-cpp)
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -111,6 +114,29 @@ if(BUILD_TESTING)
   )
   target_include_directories(test_load_schneider_plugins PRIVATE include)
   ament_target_dependencies(test_load_schneider_plugins
+    pluginlib
+    ethercat_interface
+  )
+
+  # Test Generic CiA402 Drive EtherCAT modules
+  ament_add_gmock(
+    test_load_generic_plugins
+    test/generic_plugins/test_load_ec_modules.cpp
+  )
+  target_include_directories(test_load_generic_plugins PRIVATE include)
+  ament_target_dependencies(test_load_generic_plugins
+    pluginlib
+    ethercat_interface
+  )
+  ament_add_gmock(
+    test_cia402_drive_plugin
+    test/generic_plugins/test_cia402_drive_plugin.cpp
+  )
+  target_include_directories(test_cia402_drive_plugin PRIVATE include)
+  target_link_libraries(test_cia402_drive_plugin
+    ethercat_plugins
+  )
+  ament_target_dependencies(test_cia402_drive_plugin
     pluginlib
     ethercat_interface
   )

--- a/ethercat_plugins/ethercat_plugins.xml
+++ b/ethercat_plugins/ethercat_plugins.xml
@@ -59,4 +59,7 @@
   <class name="ethercat_plugins/Schneider_ATV320" type="ethercat_plugins::Schneider_ATV320" base_class_type="ethercat_interface::EcSlave">
     <description>Schneider Electric ATV320</description>
   </class>
+  <class name="ethercat_plugins/CiA402Drive" type="ethercat_plugins::CiA402Drive" base_class_type="ethercat_interface::EcSlave">
+    <description>Generic plugin for CiA402 electrical drives.</description>
+  </class>
 </library>

--- a/ethercat_plugins/include/ethercat_plugins/commondefs.hpp
+++ b/ethercat_plugins/include/ethercat_plugins/commondefs.hpp
@@ -48,6 +48,16 @@
 #define CALIBRATION_END_NOSUCESS    ((uint16_t) 0x08)
 #define WRITE_HOMING_POSITION       ((uint16_t) 0x09)
 
+#define CiA402D_TPDO_CONTROLWORD  ((uint16_t) 0x6040)
+#define CiA402D_TPDO_POSITION  ((uint16_t) 0x607a)
+#define CiA402D_TPDO_VELOCITY  ((uint16_t) 0x60ff)
+#define CiA402D_TPDO_EFFORT  ((uint16_t) 0x6071)
+#define CiA402D_TPDO_MODE_OF_OPERATION  ((uint16_t) 0x6060)
+
+#define CiA402D_RPDO_POSITION ((uint16_t) 0x6064)
+#define CiA402D_RPDO_STATUSWORD  ((uint16_t) 0x6041)
+#define CiA402D_RPDO_MODE_OF_OPERATION_DISPLAY  ((uint16_t) 0x6061)
+
 #include <map>
 #include <string>
 

--- a/ethercat_plugins/include/ethercat_plugins/ec_pdo_channel_manager.hpp
+++ b/ethercat_plugins/include/ethercat_plugins/ec_pdo_channel_manager.hpp
@@ -1,0 +1,141 @@
+// Copyright 2023 ICUBE Laboratory, University of Strasbourg
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Maciej Bednarczyk (macbednarczyk@gmail.com)
+
+#ifndef ETHERCAT_PLUGINS__EC_PDO_CHANNEL_MANAGER_HPP_
+#define ETHERCAT_PLUGINS__EC_PDO_CHANNEL_MANAGER_HPP_
+
+#include <ecrt.h>
+#include <string>
+#include <vector>
+
+namespace ethercat_plugins
+{
+
+enum PdoType
+{
+  RPDO = 0,
+  TPDO = 1
+};
+
+class EcPdoChannelManager
+{
+public:
+  EcPdoChannelManager() {}
+  ~EcPdoChannelManager() {}
+  void setup_interface_ptrs(
+    std::vector<double> * state_interface,
+    std::vector<double> * command_interface)
+  {
+    command_interface_ptr_ = command_interface;
+    state_interface_ptr_ = state_interface;
+  }
+
+  ec_pdo_entry_info_t get_pdo_entry_info() {return {index, sub_index, type2bits(data_type)};}
+
+  double ec_read(uint8_t * domain_address)
+  {
+    if (data_type == "uint8") {
+      return static_cast<double>(EC_READ_U8(domain_address));
+    } else if (data_type == "int8") {
+      last_value = static_cast<double>(EC_READ_S8(domain_address));
+    } else if (data_type == "uint16") {
+      last_value = static_cast<double>(EC_READ_U16(domain_address));
+    } else if (data_type == "int16") {
+      last_value = static_cast<double>(EC_READ_S16(domain_address));
+    } else if (data_type == "uint32") {
+      last_value = static_cast<double>(EC_READ_U32(domain_address));
+    } else if (data_type == "int32") {
+      last_value = static_cast<double>(EC_READ_S32(domain_address));
+    } else if (data_type == "uint64") {
+      last_value = static_cast<double>(EC_READ_U64(domain_address));
+    } else if (data_type == "int64") {
+      last_value = static_cast<double>(EC_READ_S64(domain_address));
+    } else if (data_type == "test") {
+      last_value = 42;
+    }
+    return last_value;
+  }
+
+  void ec_write(uint8_t * domain_address, double value)
+  {
+    if (data_type == "uint8") {
+      EC_WRITE_U8(domain_address, static_cast<uint8_t>(value));
+    } else if (data_type == "int8") {
+      EC_WRITE_S8(domain_address, static_cast<int8_t>(value));
+    } else if (data_type == "uint16") {
+      EC_WRITE_U16(domain_address, static_cast<uint16_t>(value));
+    } else if (data_type == "int16") {
+      EC_WRITE_S16(domain_address, static_cast<int16_t>(value));
+    } else if (data_type == "uint32") {
+      EC_WRITE_U32(domain_address, static_cast<uint32_t>(value));
+    } else if (data_type == "int32") {
+      EC_WRITE_S32(domain_address, static_cast<int32_t>(value));
+    } else if (data_type == "uint64") {
+      EC_WRITE_U64(domain_address, static_cast<uint64_t>(value));
+    } else if (data_type == "int64") {
+      EC_WRITE_S64(domain_address, static_cast<int64_t>(value));
+    }
+    last_value = value;
+  }
+
+  void ec_update(uint8_t * domain_address)
+  {
+    // update state interface
+    if (pdo_type == RPDO) {
+      ec_read(domain_address);
+      if (interface_index >= 0) {
+        state_interface_ptr_->at(interface_index) = last_value;
+      }
+    } else if (pdo_type == TPDO && allow_ec_write) {
+      if (interface_index >= 0 && !std::isnan(command_interface_ptr_->at(interface_index))) {
+        ec_write(domain_address, command_interface_ptr_->at(interface_index));
+      } else {
+        ec_write(domain_address, default_value);
+      }
+    }
+  }
+
+  PdoType pdo_type;
+  uint16_t index;
+  uint8_t sub_index;
+  std::string data_type;
+  std::string interface_name;
+  uint32_t data_mask;
+  double default_value;
+  int interface_index = -1;
+  double last_value;
+  bool allow_ec_write;
+
+private:
+  std::vector<double> * command_interface_ptr_;
+  std::vector<double> * state_interface_ptr_;
+
+  uint8_t type2bits(std::string type)
+  {
+    if (type == "int8" || type == "uint8") {
+      return 8;
+    } else if (type == "int16" || type == "uint16") {
+      return 16;
+    } else if (type == "int32" || type == "uint32") {
+      return 32;
+    } else if (type == "int64" || type == "uint64") {
+      return 64;
+    }
+  }
+};
+
+}  // namespace ethercat_plugins
+#endif  // ETHERCAT_PLUGINS__EC_PDO_CHANNEL_MANAGER_HPP_

--- a/ethercat_plugins/include/ethercat_plugins/generic_plugins/cia402_drive.hpp
+++ b/ethercat_plugins/include/ethercat_plugins/generic_plugins/cia402_drive.hpp
@@ -1,0 +1,95 @@
+// Copyright 2023 ICUBE Laboratory, University of Strasbourg
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Maciej Bednarczyk (macbednarczyk@gmail.com)
+
+#ifndef ETHERCAT_PLUGINS__GENERIC_PLUGINS__CIA402_DRIVE_HPP_
+#define ETHERCAT_PLUGINS__GENERIC_PLUGINS__CIA402_DRIVE_HPP_
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+
+#include "yaml-cpp/yaml.h"
+#include "ethercat_interface/ec_slave.hpp"
+#include "ethercat_plugins/commondefs.hpp"
+#include "ethercat_plugins/ec_pdo_channel_manager.hpp"
+
+namespace ethercat_plugins
+{
+
+class CiA402Drive : public ethercat_interface::EcSlave
+{
+public:
+  CiA402Drive();
+  virtual ~CiA402Drive();
+  /** Returns true if drive has reached "operation enabled" state.
+   *  The transition through the state machine is handled automatically. */
+  bool initialized() const;
+  virtual int assign_activate_dc_sync();
+
+  virtual void processData(size_t index, uint8_t * domain_address);
+
+  virtual const ec_sync_info_t * syncs();
+  virtual size_t syncSize();
+  virtual const ec_pdo_entry_info_t * channels();
+  virtual void domains(DomainMap & domains) const;
+
+  virtual bool setupSlave(
+    std::unordered_map<std::string, std::string> slave_paramters,
+    std::vector<double> * state_interface,
+    std::vector<double> * command_interface);
+
+  int8_t mode_of_operation_display_ = 0;
+  int8_t mode_of_operation_ = 0;
+
+protected:
+  uint32_t counter_ = 0;
+  std::vector<ec_pdo_info_t> rpdos_;
+  std::vector<ec_pdo_info_t> tpdos_;
+  std::vector<ec_pdo_entry_info_t> all_channels_;
+  std::vector<EcPdoChannelManager> pdo_channels_info_;
+  std::vector<ec_sync_info_t> syncs_;
+  uint16_t last_status_word_ = -1;
+  uint16_t status_word_ = 0;
+  uint16_t control_word_ = 0;
+  DeviceState last_state_ = STATE_START;
+  DeviceState state_ = STATE_START;
+  bool initialized_ = false;
+  bool auto_fault_reset_ = false;
+  bool fault_reset_ = false;
+  int fault_reset_command_interface_index_ = -1;
+  bool last_fault_reset_command_ = false;
+  YAML::Node drive_config_;
+  uint32_t assign_activate_ = 0;
+  double last_position_ = 0;
+
+  /** returns device state based upon the status_word */
+  DeviceState deviceState(uint16_t status_word);
+
+  /** returns the control word that will take device from state to next desired state */
+  uint16_t transition(DeviceState state, uint16_t control_word);
+
+  /** set up of the drive configuration from yaml node*/
+  bool setup_from_config(YAML::Node drive_config);
+  /** set up of the drive configuration from yaml file*/
+  bool setup_from_config_file(std::string config_file);
+
+  void setup_syncs();
+
+  void setup_interface_mapping();
+};
+}  // namespace ethercat_plugins
+
+#endif  // ETHERCAT_PLUGINS__GENERIC_PLUGINS__CIA402_DRIVE_HPP_

--- a/ethercat_plugins/src/generic_plugins/cia402_drive.cpp
+++ b/ethercat_plugins/src/generic_plugins/cia402_drive.cpp
@@ -1,0 +1,381 @@
+// Copyright 2023 ICUBE Laboratory, University of Strasbourg
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Maciej Bednarczyk (macbednarczyk@gmail.com)
+
+#include <numeric>
+
+#include "ethercat_plugins/generic_plugins/cia402_drive.hpp"
+
+namespace ethercat_plugins
+{
+
+CiA402Drive::CiA402Drive()
+: EcSlave(0, 0) {}
+CiA402Drive::~CiA402Drive() {}
+/** Returns true if drive has reached "operation enabled" state.
+  *  The transition through the state machine is handled automatically. */
+bool CiA402Drive::initialized() const {return initialized_;}
+int CiA402Drive::assign_activate_dc_sync() {return assign_activate_;}
+
+void CiA402Drive::processData(size_t index, uint8_t * domain_address)
+{
+  // Special case: ControlWord
+  if (pdo_channels_info_[index].index == CiA402D_TPDO_CONTROLWORD) {
+    if (is_operational_) {
+      if (fault_reset_command_interface_index_ >= 0) {
+        if (command_interface_ptr_->at(fault_reset_command_interface_index_) == 0) {
+          last_fault_reset_command_ = false;
+        }
+        if (last_fault_reset_command_ == false &&
+          command_interface_ptr_->at(fault_reset_command_interface_index_))
+        {
+          last_fault_reset_command_ = true;
+          fault_reset_ = true;
+        }
+      }
+
+      pdo_channels_info_[index].ec_read(domain_address);
+      control_word_ = pdo_channels_info_[index].last_value;
+      control_word_ = transition(state_, control_word_);
+      pdo_channels_info_[index].ec_write(domain_address, control_word_);
+    }
+    return;
+  }
+
+  pdo_channels_info_[index].allow_ec_write = true;
+
+  if (pdo_channels_info_[index].index == CiA402D_TPDO_POSITION) {
+    if (mode_of_operation_display_ != MODE_CYCLIC_SYNC_POSITION &&
+      mode_of_operation_display_ != MODE_PROFILED_POSITION &&
+      mode_of_operation_display_ != MODE_INTERPOLATED_POSITION)
+    {  // check if allowed to write position
+      pdo_channels_info_[index].allow_ec_write = false;
+    }
+    pdo_channels_info_[index].default_value = last_position_;
+  } else if (pdo_channels_info_[index].index == CiA402D_TPDO_VELOCITY) {
+    if (mode_of_operation_display_ != MODE_CYCLIC_SYNC_VELOCITY &&
+      mode_of_operation_display_ != MODE_PROFILED_VELOCITY)
+    {  // check if allowed to write velocity
+      pdo_channels_info_[index].allow_ec_write = false;
+    }
+  } else if (pdo_channels_info_[index].index == CiA402D_TPDO_EFFORT) {
+    if (mode_of_operation_display_ != MODE_CYCLIC_SYNC_TORQUE &&
+      mode_of_operation_display_ != MODE_PROFILED_TORQUE)
+    {  // check if allowed to write effort
+      pdo_channels_info_[index].allow_ec_write = false;
+    }
+  }
+
+  pdo_channels_info_[index].ec_update(domain_address);
+
+  // get mode_of_operation_display_
+  if (pdo_channels_info_[index].index == CiA402D_RPDO_MODE_OF_OPERATION_DISPLAY) {
+    mode_of_operation_display_ = pdo_channels_info_[index].last_value;
+  }
+
+  if (pdo_channels_info_[index].index == CiA402D_RPDO_POSITION) {
+    last_position_ = pdo_channels_info_[index].last_value;
+  }
+
+  // Special case: StatusWord
+  if (pdo_channels_info_[index].index == CiA402D_RPDO_STATUSWORD) {
+    status_word_ = pdo_channels_info_[index].last_value;
+  }
+
+
+  // CHECK FOR STATE CHANGE
+  if (index == all_channels_.size() - 1) {  // if last entry  in domain
+    if (status_word_ != last_status_word_) {
+      state_ = deviceState(status_word_);
+      if (state_ != last_state_) {
+        std::cout << "STATE: " << DEVICE_STATE_STR.at(state_)
+                  << " with status word :" << status_word_ << std::endl;
+      }
+    }
+    initialized_ = ((state_ == STATE_OPERATION_ENABLED) &&
+      (last_state_ == STATE_OPERATION_ENABLED)) ? true : false;
+
+    last_status_word_ = status_word_;
+    last_state_ = state_;
+    counter_++;
+  }
+}
+
+const ec_sync_info_t * CiA402Drive::syncs()
+{
+  return syncs_.data();
+}
+size_t CiA402Drive::syncSize()
+{
+  return syncs_.size();
+}
+const ec_pdo_entry_info_t * CiA402Drive::channels()
+{
+  return all_channels_.data();
+}
+void CiA402Drive::domains(DomainMap & domains) const
+{
+  std::vector<unsigned int> v(all_channels_.size());
+  std::iota(std::begin(v), std::end(v), 0);
+  domains = {{0, v}};
+}
+
+void CiA402Drive::setup_syncs()
+{
+  syncs_.push_back({0, EC_DIR_OUTPUT, 0, NULL, EC_WD_DISABLE});
+  syncs_.push_back({1, EC_DIR_INPUT, 0, NULL, EC_WD_DISABLE});
+  syncs_.push_back({2, EC_DIR_OUTPUT, tpdos_.size(), tpdos_.data(), EC_WD_ENABLE});
+  syncs_.push_back({3, EC_DIR_INPUT, rpdos_.size(), rpdos_.data(), EC_WD_DISABLE});
+  syncs_.push_back({0xff});
+}
+
+bool CiA402Drive::setupSlave(
+  std::unordered_map<std::string, std::string> slave_paramters,
+  std::vector<double> * state_interface,
+  std::vector<double> * command_interface)
+{
+  state_interface_ptr_ = state_interface;
+  command_interface_ptr_ = command_interface;
+  paramters_ = slave_paramters;
+
+  if (paramters_.find("drive_config") != paramters_.end()) {
+    if (!setup_from_config_file(paramters_["drive_config"])) {
+      return false;
+    }
+  } else {
+    std::cerr << "CiA402_Drive: failed to find 'drive_config' tag in URDF." << std::endl;
+    return false;
+  }
+
+  if (paramters_.find("mode_of_operation") != paramters_.end()) {
+    mode_of_operation_ = std::stod(paramters_["mode_of_operation"]);
+  }
+
+  if (paramters_.find("command_interface/reset_fault") != paramters_.end()) {
+    fault_reset_command_interface_index_ = std::stoi(paramters_["command_interface/reset_fault"]);
+  }
+
+  setup_interface_mapping();
+  setup_syncs();
+
+  return true;
+}
+
+/** returns device state based upon the status_word */
+DeviceState CiA402Drive::deviceState(uint16_t status_word)
+{
+  if ((status_word & 0b01001111) == 0b00000000) {
+    return STATE_NOT_READY_TO_SWITCH_ON;
+  } else if ((status_word & 0b01001111) == 0b01000000) {
+    return STATE_SWITCH_ON_DISABLED;
+  } else if ((status_word & 0b01101111) == 0b00100001) {
+    return STATE_READY_TO_SWITCH_ON;
+  } else if ((status_word & 0b01101111) == 0b00100011) {
+    return STATE_SWITCH_ON;
+  } else if ((status_word & 0b01101111) == 0b00100111) {
+    return STATE_OPERATION_ENABLED;
+  } else if ((status_word & 0b01101111) == 0b00000111) {
+    return STATE_QUICK_STOP_ACTIVE;
+  } else if ((status_word & 0b01001111) == 0b00001111) {
+    return STATE_FAULT_REACTION_ACTIVE;
+  } else if ((status_word & 0b01001111) == 0b00001000) {
+    return STATE_FAULT;
+  }
+  return STATE_UNDEFINED;
+}
+
+/** returns the control word that will take device from state to next desired state */
+uint16_t CiA402Drive::transition(DeviceState state, uint16_t control_word)
+{
+  switch (state) {
+    case STATE_START:                     // -> STATE_NOT_READY_TO_SWITCH_ON (automatic)
+      return control_word;
+    case STATE_NOT_READY_TO_SWITCH_ON:    // -> STATE_SWITCH_ON_DISABLED (automatic)
+      return control_word;
+    case STATE_SWITCH_ON_DISABLED:        // -> STATE_READY_TO_SWITCH_ON
+      return (control_word & 0b01111110) | 0b00000110;
+    case STATE_READY_TO_SWITCH_ON:        // -> STATE_SWITCH_ON
+      return (control_word & 0b01110111) | 0b00000111;
+    case STATE_SWITCH_ON:                 // -> STATE_OPERATION_ENABLED
+      return (control_word & 0b01111111) | 0b00001111;
+    case STATE_OPERATION_ENABLED:         // -> GOOD
+      return control_word;
+    case STATE_QUICK_STOP_ACTIVE:         // -> STATE_OPERATION_ENABLED
+      return (control_word & 0b01111111) | 0b00001111;
+    case STATE_FAULT_REACTION_ACTIVE:     // -> STATE_FAULT (automatic)
+      return control_word;
+    case STATE_FAULT:                     // -> STATE_SWITCH_ON_DISABLED
+      if (auto_fault_reset_ || fault_reset_) {
+        fault_reset_ = false;
+        return (control_word & 0b11111111) | 0b10000000;     // automatic reset
+      } else {
+        return control_word;
+      }
+    default:
+      break;
+  }
+  return control_word;
+}
+
+bool CiA402Drive::setup_from_config(YAML::Node drive_config)
+{
+  if (drive_config.size() != 0) {
+    if (drive_config["vendor_id"]) {
+      vendor_id_ = drive_config["vendor_id"].as<uint32_t>();
+    } else {
+      std::cerr << "CiA402_Drive: failed to load drive vendor ID." << std::endl;
+      return false;
+    }
+    if (drive_config["product_id"]) {
+      product_id_ = drive_config["product_id"].as<uint32_t>();
+    } else {
+      std::cerr << "CiA402_Drive: failed to load drive product ID." << std::endl;
+      return false;
+    }
+    if (drive_config["assign_activate"]) {
+      assign_activate_ = drive_config["assign_activate"].as<uint32_t>();
+    }
+    if (drive_config["auto_fault_reset"]) {
+      auto_fault_reset_ = drive_config["auto_fault_reset"].as<bool>();
+    }
+    if (drive_config["sdo"]) {
+      for (const auto & sdo : drive_config["sdo"]) {
+        // todo read sdo
+      }
+    }
+
+    auto channels_nbr = 0;
+
+    if (drive_config["tpdo"]) {
+      for (auto i = 0ul; i < drive_config["tpdo"].size(); i++) {
+        channels_nbr += drive_config["tpdo"][i]["channels"].size();
+      }
+    }
+    if (drive_config["rpdo"]) {
+      for (auto i = 0ul; i < drive_config["rpdo"].size(); i++) {
+        channels_nbr += drive_config["rpdo"][i]["channels"].size();
+      }
+    }
+
+    all_channels_.reserve(channels_nbr);
+    channels_nbr = 0;
+
+    if (drive_config["tpdo"]) {
+      for (auto i = 0ul; i < drive_config["tpdo"].size(); i++) {
+        auto tpdo_channels_size = drive_config["tpdo"][i]["channels"].size();
+        for (auto c = 0ul; c < tpdo_channels_size; c++) {
+          EcPdoChannelManager channel_info;
+          channel_info.pdo_type = TPDO;
+          channel_info.index = drive_config["tpdo"][i]["channels"][c]["index"].as<uint16_t>();
+          channel_info.sub_index =
+            drive_config["tpdo"][i]["channels"][c]["sub_index"].as<uint8_t>();
+          channel_info.data_type = drive_config["tpdo"][i]["channels"][c]["type"].as<std::string>();
+          channel_info.interface_name =
+            drive_config["tpdo"][i]["channels"][c]["command_interface"].as<std::string>();
+          channel_info.default_value =
+            drive_config["tpdo"][i]["channels"][c]["default"].as<double>();
+          pdo_channels_info_.push_back(channel_info);
+          all_channels_.push_back(channel_info.get_pdo_entry_info());
+        }
+        tpdos_.push_back(
+          {
+            drive_config["tpdo"][i]["index"].as<uint16_t>(),
+            tpdo_channels_size,
+            all_channels_.data() + channels_nbr
+          }
+        );
+        channels_nbr += tpdo_channels_size;
+      }
+    }
+
+    if (drive_config["rpdo"]) {
+      for (auto i = 0ul; i < drive_config["rpdo"].size(); i++) {
+        auto rpdo_channels_size = drive_config["rpdo"][i]["channels"].size();
+
+        for (auto c = 0ul; c < rpdo_channels_size; c++) {
+          EcPdoChannelManager channel_info;
+          channel_info.pdo_type = RPDO;
+          channel_info.index = drive_config["rpdo"][i]["channels"][c]["index"].as<uint16_t>();
+          channel_info.sub_index =
+            drive_config["rpdo"][i]["channels"][c]["sub_index"].as<uint8_t>();
+          channel_info.data_type = drive_config["rpdo"][i]["channels"][c]["type"].as<std::string>();
+          channel_info.interface_name =
+            drive_config["rpdo"][i]["channels"][c]["state_interface"].as<std::string>();
+          channel_info.default_value = std::numeric_limits<double>::quiet_NaN();
+          pdo_channels_info_.push_back(channel_info);
+          all_channels_.push_back(channel_info.get_pdo_entry_info());
+        }
+        rpdos_.push_back(
+          {
+            drive_config["rpdo"][i]["index"].as<uint16_t>(),
+            rpdo_channels_size,
+            all_channels_.data() + channels_nbr
+          }
+        );
+        channels_nbr += rpdo_channels_size;
+      }
+    }
+
+    return true;
+  } else {
+    std::cerr << "CiA402_Drive: failed to load drive configuration: empty configuration" <<
+      std::endl;
+    return false;
+  }
+}
+
+bool CiA402Drive::setup_from_config_file(std::string config_file)
+{
+  // Read drive configuration from YAML file
+  try {
+    drive_config_ = YAML::LoadFile(config_file);
+  } catch (const YAML::ParserException & ex) {
+    std::cerr << "CiA402_Drive: failed to load drive configuration: " << ex.what() << std::endl;
+    return false;
+  } catch (const YAML::BadFile & ex) {
+    std::cerr << "CiA402_Drive: failed to load drive configuration: " << ex.what() << std::endl;
+    return false;
+  }
+  if (!setup_from_config(drive_config_)) {
+    return false;
+  }
+  return true;
+}
+
+void CiA402Drive::setup_interface_mapping()
+{
+  for (auto & channel : pdo_channels_info_) {
+    if (channel.pdo_type == RPDO) {
+      if (paramters_.find("state_interface/" + channel.interface_name) != paramters_.end()) {
+        channel.interface_index =
+          std::stoi(paramters_["state_interface/" + channel.interface_name]);
+      }
+    }
+    if (channel.pdo_type == TPDO) {
+      if (paramters_.find("command_interface/" + channel.interface_name) != paramters_.end()) {
+        channel.interface_index = std::stoi(
+          paramters_["command_interface/" + channel.interface_name]);
+      }
+    }
+
+    channel.setup_interface_ptrs(state_interface_ptr_, command_interface_ptr_);
+  }
+}
+
+}  // namespace ethercat_plugins
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(ethercat_plugins::CiA402Drive, ethercat_interface::EcSlave)

--- a/ethercat_plugins/test/generic_plugins/test_cia402_drive_plugin.cpp
+++ b/ethercat_plugins/test/generic_plugins/test_cia402_drive_plugin.cpp
@@ -1,0 +1,246 @@
+// Copyright 2023 ICUBE Laboratory, University of Strasbourg
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <map>
+#include <pluginlib/class_loader.hpp>
+#include "ethercat_interface/ec_slave.hpp"
+#include "test_cia402_drive_plugin.hpp"
+
+const char test_drive_config[] =
+  R"(
+# Configuration file for Test drive
+vendor_id: 0x00000011
+product_id: 0x07030924
+assign_activate: 0x0321  # DC Synch register
+period: 100  # Hz
+auto_fault_reset: false  # true = automatic fault reset, false = fault reset on rising edge command interface "reset_fault"
+sdo:  # sdo data to be transferred at drive startup
+  - {index: 0x60C2, sub_index: 1, value: 10} # Set interpolation time for cyclic modes to 10 ms
+  - {index: 0x60C2, sub_index: 2, value: -3} # Set base 10-3s
+tpdo:  # TxPDO
+  - index: 0x1607
+    channels:
+      - {index: 0x607a, sub_index: 0, type: int32, command_interface: position, default: .nan}  # Target position
+      - {index: 0x60ff, sub_index: 0, type: int32, command_interface: velocity, default: 0}  # Target velocity
+      - {index: 0x6071, sub_index: 0, type: test, command_interface: effort, default: -5}  # Target torque
+      - {index: 0x6072, sub_index: 0, type: int16, command_interface: ~, default: 1000}  # Max torque
+      - {index: 0x6040, sub_index: 0, type: uint16, command_interface: ~, default: 0}  # Control word
+      - {index: 0x6060, sub_index: 0, type: int8, command_interface: ~, default: 8}  # Mode of operation
+rpdo:  # RxPDO
+  - index: 0x1a07
+    channels:
+      - {index: 0x6064, sub_index: 0, type: int32, state_interface: position}  # Position actual value
+      - {index: 0x606c, sub_index: 0, type: int32, state_interface: velocity}  # Velocity actual value
+      - {index: 0x6077, sub_index: 0, type: test, state_interface: effort}  # Torque actual value
+      - {index: 0x6041, sub_index: 0, type: uint16, state_interface: ~}  # Status word
+      - {index: 0x6061, sub_index: 0, type: int8, state_interface: ~}  # Mode of operation display
+  - index: 0x1a45
+    channels:
+      - {index: 0x2205, sub_index: 1, type: int16, state_interface: analog_input1}  # Analog input
+      - {index: 0x2205, sub_index: 2, type: int16, state_interface: analog_input2}  # Analog input
+)";
+
+void CiA402DriveTest::SetUp()
+{
+  plugin_ = std::make_unique<FriendCiA402Drive>();
+}
+
+void CiA402DriveTest::TearDown()
+{
+  plugin_.reset(nullptr);
+}
+
+TEST_F(CiA402DriveTest, SlaveSetupNoDriveConfig)
+{
+  SetUp();
+  std::vector<double> state_interface = {0};
+  std::vector<double> command_interface = {0};
+  std::unordered_map<std::string, std::string> slave_paramters;
+  // setup failed, 'drive_config' parameter not set
+  ASSERT_EQ(
+    plugin_->setupSlave(
+      slave_paramters,
+      &state_interface,
+      &command_interface
+    ),
+    false
+  );
+}
+
+TEST_F(CiA402DriveTest, SlaveSetupMissingFileDriveConfig)
+{
+  SetUp();
+  std::vector<double> state_interface = {0};
+  std::vector<double> command_interface = {0};
+  std::unordered_map<std::string, std::string> slave_paramters;
+  slave_paramters["drive_config"] = "drive_config.yaml";
+  // setup failed, 'drive_config.yaml' file not set
+  ASSERT_EQ(
+    plugin_->setupSlave(
+      slave_paramters,
+      &state_interface,
+      &command_interface
+    ),
+    false
+  );
+}
+
+TEST_F(CiA402DriveTest, SlaveSetupDriveFromConfig)
+{
+  SetUp();
+  ASSERT_EQ(
+    plugin_->setup_from_config(YAML::Load(test_drive_config)),
+    true
+  );
+  ASSERT_EQ(plugin_->vendor_id_, 0x00000011);
+  ASSERT_EQ(plugin_->product_id_, 0x07030924);
+  ASSERT_EQ(plugin_->assign_activate_, 0x0321);
+  ASSERT_EQ(plugin_->auto_fault_reset_, false);
+
+  ASSERT_EQ(plugin_->tpdos_.size(), 1);
+  ASSERT_EQ(plugin_->tpdos_[0].index, 0x1607);
+
+  ASSERT_EQ(plugin_->rpdos_.size(), 2);
+  ASSERT_EQ(plugin_->rpdos_[0].index, 0x1a07);
+  ASSERT_EQ(plugin_->rpdos_[1].index, 0x1a45);
+
+  ASSERT_EQ(plugin_->pdo_channels_info_[1].interface_name, "velocity");
+  ASSERT_EQ(plugin_->pdo_channels_info_[3].default_value, 1000);
+  ASSERT_TRUE(std::isnan(plugin_->pdo_channels_info_[0].default_value));
+  ASSERT_EQ(plugin_->pdo_channels_info_[4].interface_name, "null");
+  ASSERT_EQ(plugin_->pdo_channels_info_[12].interface_name, "analog_input2");
+  ASSERT_EQ(plugin_->pdo_channels_info_[4].data_type, "uint16");
+}
+
+TEST_F(CiA402DriveTest, SlaveSetupPdoChannels)
+{
+  SetUp();
+  plugin_->setup_from_config(YAML::Load(test_drive_config));
+  std::vector<ec_pdo_entry_info_t> channels(
+    plugin_->channels(),
+    plugin_->channels() + plugin_->all_channels_.size()
+  );
+
+  ASSERT_EQ(channels.size(), 13);
+  ASSERT_EQ(channels[0].index, 0x607a);
+  ASSERT_EQ(channels[11].index, 0x2205);
+  ASSERT_EQ(channels[11].subindex, 0x01);
+}
+
+TEST_F(CiA402DriveTest, SlaveSetupSyncs)
+{
+  SetUp();
+  plugin_->setup_from_config(YAML::Load(test_drive_config));
+  plugin_->setup_syncs();
+  std::vector<ec_sync_info_t> syncs(
+    plugin_->syncs(),
+    plugin_->syncs() + plugin_->syncSize()
+  );
+
+  ASSERT_EQ(syncs.size(), 5);
+  ASSERT_EQ(syncs[1].index, 1);
+  ASSERT_EQ(syncs[1].dir, EC_DIR_INPUT);
+  ASSERT_EQ(syncs[1].n_pdos, 0);
+  ASSERT_EQ(syncs[1].watchdog_mode, EC_WD_DISABLE);
+  ASSERT_EQ(syncs[2].dir, EC_DIR_OUTPUT);
+  ASSERT_EQ(syncs[2].n_pdos, 1);
+  ASSERT_EQ(syncs[3].index, 3);
+  ASSERT_EQ(syncs[3].dir, EC_DIR_INPUT);
+  ASSERT_EQ(syncs[3].n_pdos, 2);
+  ASSERT_EQ(syncs[3].watchdog_mode, EC_WD_DISABLE);
+}
+
+TEST_F(CiA402DriveTest, SlaveSetupDomains)
+{
+  SetUp();
+  plugin_->setup_from_config(YAML::Load(test_drive_config));
+  std::map<unsigned int, std::vector<unsigned int>> domains;
+  plugin_->domains(domains);
+
+  ASSERT_EQ(domains[0].size(), 13);
+  ASSERT_EQ(domains[0][0], 0);
+  ASSERT_EQ(domains[0][12], 12);
+}
+
+TEST_F(CiA402DriveTest, EcReadRPDOToStateInterface)
+{
+  SetUp();
+  std::unordered_map<std::string, std::string> slave_paramters;
+  std::vector<double> state_interface = {0, 0};
+  plugin_->state_interface_ptr_ = &state_interface;
+  slave_paramters["state_interface/effort"] = "1";
+  plugin_->paramters_ = slave_paramters;
+  plugin_->setup_from_config(YAML::Load(test_drive_config));
+  plugin_->setup_interface_mapping();
+  ASSERT_EQ(plugin_->pdo_channels_info_[8].interface_index, 1);
+  uint8_t domain_address = 0;
+  plugin_->processData(8, &domain_address);
+  ASSERT_EQ(plugin_->state_interface_ptr_->at(1), 42);
+}
+
+TEST_F(CiA402DriveTest, EcWriteTPDOFromCommandInterface)
+{
+  SetUp();
+  std::unordered_map<std::string, std::string> slave_paramters;
+  std::vector<double> command_interface = {0, 42};
+  plugin_->command_interface_ptr_ = &command_interface;
+  slave_paramters["command_interface/effort"] = "1";
+  plugin_->paramters_ = slave_paramters;
+  plugin_->setup_from_config(YAML::Load(test_drive_config));
+  plugin_->setup_interface_mapping();
+  ASSERT_EQ(plugin_->pdo_channels_info_[2].interface_index, 1);
+  plugin_->mode_of_operation_display_ = 10;
+  uint8_t domain_address = 0;
+  plugin_->processData(2, &domain_address);
+  ASSERT_EQ(plugin_->pdo_channels_info_[2].last_value, 42);
+}
+
+TEST_F(CiA402DriveTest, EcWriteTPDODefaultValue)
+{
+  SetUp();
+  plugin_->setup_from_config(YAML::Load(test_drive_config));
+  plugin_->setup_interface_mapping();
+  plugin_->mode_of_operation_display_ = 10;
+  uint8_t domain_address = 0;
+  plugin_->processData(2, &domain_address);
+  ASSERT_EQ(plugin_->pdo_channels_info_[2].last_value, -5);
+}
+
+TEST_F(CiA402DriveTest, FaultReset)
+{
+  std::unordered_map<std::string, std::string> slave_paramters;
+  std::vector<double> command_interface = {0, 1};
+  plugin_->command_interface_ptr_ = &command_interface;
+  plugin_->setup_from_config(YAML::Load(test_drive_config));
+  plugin_->setup_interface_mapping();
+  plugin_->fault_reset_command_interface_index_ = 1;
+  plugin_->state_ = STATE_FAULT;
+  plugin_->is_operational_ = true;
+  uint8_t domain_address = 0;
+  plugin_->pdo_channels_info_[4].data_type = "";
+  ASSERT_FALSE(plugin_->last_fault_reset_command_);
+  ASSERT_FALSE(plugin_->fault_reset_);
+  ASSERT_EQ(plugin_->command_interface_ptr_->at(plugin_->fault_reset_command_interface_index_), 1);
+  plugin_->processData(4, &domain_address);
+  ASSERT_EQ(plugin_->control_word_, 0b10000000);
+  plugin_->pdo_channels_info_[4].last_value = 0;
+  plugin_->processData(4, &domain_address);
+  ASSERT_EQ(plugin_->control_word_, 0b00000000);
+  command_interface[1] = 0;
+  plugin_->processData(4, &domain_address);
+  ASSERT_EQ(plugin_->control_word_, 0b00000000);
+  command_interface[1] = 2;
+  plugin_->processData(4, &domain_address);
+  ASSERT_EQ(plugin_->control_word_, 0b10000000);
+}

--- a/ethercat_plugins/test/generic_plugins/test_cia402_drive_plugin.hpp
+++ b/ethercat_plugins/test/generic_plugins/test_cia402_drive_plugin.hpp
@@ -1,0 +1,50 @@
+// Copyright 2023 ICUBE Laboratory, University of Strasbourg
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GENERIC_PLUGINS__TEST_CIA402_DRIVE_PLUGIN_HPP_
+#define GENERIC_PLUGINS__TEST_CIA402_DRIVE_PLUGIN_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+#include "gmock/gmock.h"
+
+#include "ethercat_plugins/generic_plugins/cia402_drive.hpp"
+
+// subclassing and friending so we can access member variables
+class FriendCiA402Drive : public ethercat_plugins::CiA402Drive
+{
+  FRIEND_TEST(CiA402DriveTest, SlaveSetupDriveFromConfig);
+  FRIEND_TEST(CiA402DriveTest, SlaveSetupPdoChannels);
+  FRIEND_TEST(CiA402DriveTest, SlaveSetupSyncs);
+  FRIEND_TEST(CiA402DriveTest, SlaveSetupDomains);
+  FRIEND_TEST(CiA402DriveTest, EcReadRPDOToStateInterface);
+  FRIEND_TEST(CiA402DriveTest, EcWriteTPDOFromCommandInterface);
+  FRIEND_TEST(CiA402DriveTest, EcWriteTPDODefaultValue);
+  FRIEND_TEST(CiA402DriveTest, FaultReset);
+};
+
+class CiA402DriveTest : public ::testing::Test
+{
+public:
+  void SetUp();
+  void TearDown();
+
+protected:
+  std::unique_ptr<FriendCiA402Drive> plugin_;
+};
+
+#endif  // GENERIC_PLUGINS__TEST_CIA402_DRIVE_PLUGIN_HPP_

--- a/ethercat_plugins/test/generic_plugins/test_load_ec_modules.cpp
+++ b/ethercat_plugins/test/generic_plugins/test_load_ec_modules.cpp
@@ -1,0 +1,26 @@
+// Copyright 2023 ICUBE Laboratory, University of Strasbourg
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include <pluginlib/class_loader.hpp>
+#include "ethercat_interface/ec_slave.hpp"
+
+TEST(TestLoadCiA402Drive, load_ec_module)
+{
+  pluginlib::ClassLoader<ethercat_interface::EcSlave> ec_loader_{
+    "ethercat_interface", "ethercat_interface::EcSlave"};
+  ASSERT_NO_THROW(ec_loader_.createSharedInstance("ethercat_plugins/CiA402Drive"));
+}


### PR DESCRIPTION
Generic module for EtherCAT compatible cia402 drives that can be configured using a parameter file. 
Test code not to be merged.
Split into PR #43  and PR #44 