### PR TITLE
Round values when using masks and factors or offsets at the same time

### DIFF
--- a/ethercat_interface/include/ethercat_interface/ec_pdo_channel_manager.hpp
+++ b/ethercat_interface/include/ethercat_interface/ec_pdo_channel_manager.hpp
@@ -94,6 +94,9 @@ public:
       buffer_ = EC_READ_U8(domain_address);
       if (popcount(data_mask) == 1) {
         buffer_ &= (data_mask - 1);
+        if(factor != 1 || offset != 0) {
+            value = round(value);
+        }
         if (value) {buffer_ += data_mask;}
       } else if (data_mask != 0) {
         buffer_ = 0;


### PR DESCRIPTION
When using the bool type in combination with a factor, the outcome is not as expected.

I use this to have an on/off contact which drives a pneumatic cilinder with length of 0.25m.

Factor in this case will be 4. 
During planning the value will be between 0 and 1, but due to rounding errors it never get's to 1, always stays at 0.9999...

With this rounding, we now can use this to round the 0.9999 to a 1.