### PR TITLE
remove ethercat_plugins dependency

### DIFF
--- a/ethercat_driver_ros2/package.xml
+++ b/ethercat_driver_ros2/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <exec_depend>ethercat_driver</exec_depend>
   <exec_depend>ethercat_interface</exec_depend>
-  <exec_depend>ethercat_plugins</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Hi, this is only a very small adjustment. As mentioned in #64 the ethercat_plugins dependency in the package.xml is outdated, so I removed it.