### PR TITLE
Depreciating ethercat plugins

### DIFF
--- a/ethercat_plugins/ethercat_advantech_modules/src/amax5051.cpp
+++ b/ethercat_plugins/ethercat_advantech_modules/src/amax5051.cpp
@@ -21,7 +21,11 @@ class Advantech_AMAX5051 : public ethercat_interface::EcSlave
 {
 public:
   Advantech_AMAX5051()
-  : EcSlave(0x000013FE, 0x00035051) {}
+  : EcSlave(0x000013FE, 0x00035051)
+  {
+    std::cerr << "The Advantech_AMAX5051 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Advantech_AMAX5051() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_advantech_modules/src/amax5056.cpp
+++ b/ethercat_plugins/ethercat_advantech_modules/src/amax5056.cpp
@@ -21,7 +21,11 @@ class Advantech_AMAX5056 : public ethercat_interface::EcSlave
 {
 public:
   Advantech_AMAX5056()
-  : EcSlave(0x000013FE, 0x00035056) {}
+  : EcSlave(0x000013FE, 0x00035056)
+  {
+    std::cerr << "The Advantech_AMAX5056 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Advantech_AMAX5056() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_ati_modules/src/ati_ft_sensor.cpp
+++ b/ethercat_plugins/ethercat_ati_modules/src/ati_ft_sensor.cpp
@@ -21,7 +21,11 @@ class ATI_FTSensor : public ethercat_interface::EcSlave
 {
 public:
   ATI_FTSensor()
-  : EcSlave(0x00000732, 0x26483052) {}
+  : EcSlave(0x00000732, 0x26483052)
+  {
+    std::cerr << "The ATI_FTSensor plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~ATI_FTSensor() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_ek1100.cpp
+++ b/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_ek1100.cpp
@@ -21,7 +21,11 @@ class Beckhoff_EK1100 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EK1100()
-  : EcSlave(0x00000002, 0x044c2c52) {}
+  : EcSlave(0x00000002, 0x044c2c52)
+  {
+    std::cerr << "The Beckhoff_EK1100 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EK1100() {}
 };
 

--- a/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el10xx.cpp
+++ b/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el10xx.cpp
@@ -21,7 +21,11 @@ class Beckhoff_EL1008 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EL1008()
-  : EcSlave(0x00000002, 0x03f03052) {}
+  : EcSlave(0x00000002, 0x03f03052)
+  {
+    std::cerr << "The Beckhoff_EL1008 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EL1008() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {
@@ -116,7 +120,11 @@ class Beckhoff_EL1018 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EL1018()
-  : EcSlave(0x00000002, 0x03fa3052) {}
+  : EcSlave(0x00000002, 0x03fa3052)
+  {
+    std::cerr << "The Beckhoff_EL1018 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EL1018() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el20xx.cpp
+++ b/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el20xx.cpp
@@ -21,7 +21,11 @@ class Beckhoff_EL2008 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EL2008()
-  : EcSlave(0x00000002, 0x07d83052) {}
+  : EcSlave(0x00000002, 0x07d83052)
+  {
+    std::cerr << "The Beckhoff_EL2008 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EL2008() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {
@@ -130,7 +134,11 @@ class Beckhoff_EL2088 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EL2088()
-  : EcSlave(0x00000002, 0x08283052) {}
+  : EcSlave(0x00000002, 0x08283052)
+  {
+    std::cerr << "The Beckhoff_EL2088 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EL2088() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el21xx.cpp
+++ b/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el21xx.cpp
@@ -21,7 +21,11 @@ class Beckhoff_EL2124 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EL2124()
-  : EcSlave(0x00000002, 0x084c3052) {}
+  : EcSlave(0x00000002, 0x084c3052)
+  {
+    std::cerr << "The Beckhoff_EL2124 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EL2124() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el31xx.cpp
+++ b/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el31xx.cpp
@@ -21,7 +21,11 @@ class Beckhoff_EL3102 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EL3102()
-  : EcSlave(0x00000002, 0x0c1e3052) {}
+  : EcSlave(0x00000002, 0x0c1e3052)
+  {
+    std::cerr << "The Beckhoff_EL3102 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EL3102() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {
@@ -97,7 +101,11 @@ class Beckhoff_EL3104 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EL3104()
-  : EcSlave(0x00000002, 0x0c203052) {}
+  : EcSlave(0x00000002, 0x0c203052)
+  {
+    std::cerr << "The Beckhoff_EL3104 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EL3104() {}
   virtual void processData(size_t index, uint8_t domain_address)
   {

--- a/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el41xx.cpp
+++ b/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el41xx.cpp
@@ -21,7 +21,11 @@ class Beckhoff_EL4134 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EL4134()
-  : EcSlave(0x00000002, 0x10263052) {}
+  : EcSlave(0x00000002, 0x10263052)
+  {
+    std::cerr << "The Beckhoff_EL4134 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EL4134() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {
@@ -109,7 +113,11 @@ class Beckhoff_EL4132 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EL4132()
-  : EcSlave(0x00000002, 0x10243052) {}
+  : EcSlave(0x00000002, 0x10243052)
+  {
+    std::cerr << "The Beckhoff_EL4132 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EL4132() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el5101.cpp
+++ b/ethercat_plugins/ethercat_beckhoff_modules/src/beckhoff_el5101.cpp
@@ -24,7 +24,11 @@ class Beckhoff_EL5101 : public ethercat_interface::EcSlave
 {
 public:
   Beckhoff_EL5101()
-  : EcSlave(0x00000002, 0x13ed3052) {}
+  : EcSlave(0x00000002, 0x13ed3052)
+  {
+    std::cerr << "The Beckhoff_EL5101 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Beckhoff_EL5101() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_maxon_drives/src/maxon_epos3.cpp
+++ b/ethercat_plugins/ethercat_maxon_drives/src/maxon_epos3.cpp
@@ -22,7 +22,11 @@ class Maxon_EPOS3 : public ethercat_interface::EcSlave
 {
 public:
   Maxon_EPOS3()
-  : EcSlave(0x000000fb, 0x64400000) {}
+  : EcSlave(0x000000fb, 0x64400000)
+  {
+    std::cerr << "The Maxon_EPOS3 plugin is depreciated and will be removed in the future."
+              << "Use the EcCiA402Drive plugin instead." << std::endl;
+  }
   virtual ~Maxon_EPOS3() {}
   /** Returns true if Epos3 has reached "operation enabled" state.
     *  The transition through the state machine is handled automatically. */

--- a/ethercat_plugins/ethercat_omron_modules/src/omron_nx_ecc201_nx_id5442.cpp
+++ b/ethercat_plugins/ethercat_omron_modules/src/omron_nx_ecc201_nx_id5442.cpp
@@ -21,7 +21,12 @@ class Omron_NX_ECC201_NX_ID5442 : public ethercat_interface::EcSlave
 {
 public:
   Omron_NX_ECC201_NX_ID5442()
-  : EcSlave(0x00000083, 0x00000083) {}
+  : EcSlave(0x00000083, 0x00000083)
+  {
+    std::cerr <<
+      "The Omron_NX_ECC201_NX_ID5442 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Omron_NX_ECC201_NX_ID5442() {}
   virtual void processData(size_t /*index*/, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_omron_modules/src/omron_nx_ecc201_nx_od5256.cpp
+++ b/ethercat_plugins/ethercat_omron_modules/src/omron_nx_ecc201_nx_od5256.cpp
@@ -22,7 +22,12 @@ class Omron_NX_ECC201_NX_OD5256 : public ethercat_interface::EcSlave
 {
 public:
   Omron_NX_ECC201_NX_OD5256()
-  : EcSlave(0x00000083, 0x00000083) {}
+  : EcSlave(0x00000083, 0x00000083)
+  {
+    std::cerr <<
+      "The Omron_NX_ECC201_NX_OD5256 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Omron_NX_ECC201_NX_OD5256() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_omron_modules/src/omron_nx_ecc202_nx_id5142_1.cpp
+++ b/ethercat_plugins/ethercat_omron_modules/src/omron_nx_ecc202_nx_id5142_1.cpp
@@ -21,7 +21,12 @@ class Omron_NX_ECC202_NX_ID5142_1 : public ethercat_interface::EcSlave
 {
 public:
   Omron_NX_ECC202_NX_ID5142_1()
-  : EcSlave(0x00000083, 0x000000a6) {}
+  : EcSlave(0x00000083, 0x000000a6)
+  {
+    std::cerr <<
+      "The Omron_NX_ECC202_NX_ID5142_1 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   // 0x01115142 for NX-ID5142-1 and 0x05115142 for NX-ID5142-5
   virtual ~Omron_NX_ECC202_NX_ID5142_1() {}
   virtual void processData(size_t index, uint8_t * domain_address)

--- a/ethercat_plugins/ethercat_omron_modules/src/omron_nx_ecc202_nx_od5256.cpp
+++ b/ethercat_plugins/ethercat_omron_modules/src/omron_nx_ecc202_nx_od5256.cpp
@@ -21,7 +21,12 @@ class Omron_NX_ECC202_NX_OD5256 : public ethercat_interface::EcSlave
 {
 public:
   Omron_NX_ECC202_NX_OD5256()
-  : EcSlave(0x00000083, 0x000000a6) {}
+  : EcSlave(0x00000083, 0x000000a6)
+  {
+    std::cerr <<
+      "The Omron_NX_ECC202_NX_OD5256 plugin is depreciated and will be removed in the future."
+              << "Use the GenericEcSlave plugin instead." << std::endl;
+  }
   virtual ~Omron_NX_ECC202_NX_OD5256() {}
   virtual void processData(size_t index, uint8_t * domain_address)
   {

--- a/ethercat_plugins/ethercat_schneider_drives/src/schneider_atv320.cpp
+++ b/ethercat_plugins/ethercat_schneider_drives/src/schneider_atv320.cpp
@@ -22,7 +22,11 @@ class Schneider_ATV320 : public ethercat_interface::EcSlave
 {
 public:
   Schneider_ATV320()
-  : EcSlave(0x0800005a, 0x00000389) {}
+  : EcSlave(0x0800005a, 0x00000389)
+  {
+    std::cerr << "The Schneider_ATV320 plugin is depreciated and will be removed in the future."
+              << "Use the EcCiA402Drive plugin instead." << std::endl;
+  }
   virtual ~Schneider_ATV320() {}
   /* Returns true if atv320 has reached "operation enabled" state. */
   bool initialized() const {return state_ == STATE_OPERATION_ENABLED;}


### PR DESCRIPTION
Depreciating ethercat plugins to be used with generic plugins﻿. Module configuration is ported to [example repo](https://github.com/ICube-Robotics/ethercat_driver_ros2_examples)
