### PR TITLE
Added mode_of_operation_display_ when setting up slave, to have the s…

### DIFF
--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -129,6 +129,7 @@ bool EcCiA402Drive::setupSlave(
 
   if (paramters_.find("mode_of_operation") != paramters_.end()) {
     mode_of_operation_ = std::stod(paramters_["mode_of_operation"]);
+    mode_of_operation_display_ = std::stod(paramters_["mode_of_operation"]);
   }
 
   if (paramters_.find("command_interface/reset_fault") != paramters_.end()) {


### PR DESCRIPTION
Added mode_of_operation_display_ when setting up slave, to have the same value as mode_of_operation from parameters. If 0x6061 isn't read, the rest still works as intended.

https://github.com/ICube-Robotics/ethercat_driver_ros2/issues/125#issuecomment-2188129291
