### PR TITLE
Multi-master and non-zero master support

### DIFF
--- a/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
@@ -83,7 +83,7 @@ private:
     "ethercat_interface", "ethercat_interface::EcSlave"};
 
   int control_frequency_;
-  ethercat_interface::EcMaster master_;
+  std::unique_ptr<ethercat_interface::EcMaster> master_;
   std::mutex ec_mutex_;
   bool activated_;
 };

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -339,12 +339,12 @@ CallbackReturn EthercatDriver::on_activate(
     // update EtherCAT bus
 
     master_->update();
-    RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "updated!");
+    // RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "updated!");
 
     // check if operational
     bool isAllInit = true;
     for (auto & module : ec_modules_) {
-      isAllInit = isAllInit && module->initialized();
+      isAllInit = isAllInit && module->initialized() && module->is_operational();
     }
     if (isAllInit) {
       running = false;

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -339,12 +339,12 @@ CallbackReturn EthercatDriver::on_activate(
     // update EtherCAT bus
 
     master_->update();
-    // RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "updated!");
+    RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "updated!");
 
     // check if operational
     bool isAllInit = true;
     for (auto & module : ec_modules_) {
-      isAllInit = isAllInit && module->initialized() && module->is_operational();
+      isAllInit = isAllInit && module->initialized();
     }
     if (isAllInit) {
       running = false;

--- a/ethercat_driver_ros2/sphinx/user_guide/config_generic_slave.rst
+++ b/ethercat_driver_ros2/sphinx/user_guide/config_generic_slave.rst
@@ -83,6 +83,12 @@ Each PDO Channel has the following configuration flags:
     - Data conversion factor/scale (:code:`type` : :code:`double`).
   * - :code:`offset`
     - Data offset term (:code:`type` : :code:`double`).
+  * - :code:`peak_upper_limit`
+    - Peak Upper limit (:code:`type` : :code:`double`) applied to command_interface as saturation before multiplying factor and adding offset. default value is :code:`6.2831853` (2*PI).
+  * - :code:`peak_lower_limit`
+    - Peak Lower limit (:code:`type` : :code:`double`) applied to command_interface as saturation before multiplying factor and adding offset. default value is :code:`-6.2831853` (-2*PI).
+  * - :code:`peak_limit_multiplier`
+    - Peak limit multiplier (:code:`type` : :code:`double`) applied to peak limits to scale them slightly below the actual actuator limits (specified in peak upper/lower limits). This is useful to avoid hitting the limits during operation.
 
 
 .. warning:: For each channel, tags :code:`index`, :code:`sub_index` and :code:`type` are **mandatory** even if the channel is not used in order to fill the data layout expected by the module. All other tags can remain unset.

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/cia402_common_defs.hpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/cia402_common_defs.hpp
@@ -24,6 +24,7 @@
 #define CiA402D_TPDO_POSITION ((uint16_t) 0x6064)
 #define CiA402D_TPDO_STATUSWORD  ((uint16_t) 0x6041)
 #define CiA402D_TPDO_MODE_OF_OPERATION_DISPLAY  ((uint16_t) 0x6061)
+#define CiA402D_TPDO_ERROR_CODE  ((uint16_t) 0x603f)
 
 #include <map>
 #include <string>

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
@@ -38,7 +38,7 @@ public:
   virtual ~EcCiA402Drive();
   /** Returns true if drive has reached "operation enabled" state.
    *  The transition through the state machine is handled automatically. */
-  bool initialized() const;
+  bool initialized() override;
 
   virtual void processData(size_t index, uint8_t * domain_address);
 

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
@@ -71,6 +71,9 @@ protected:
   bool temperature_fault_detected_ = false;
   uint16_t error_code_ = 0;
 
+  // Quick stop behavior controls
+  bool exclude_from_global_quick_stop_ = false; // Do not propagate this drive's faults globally if true
+
   /** returns device state based upon the status_word */
   DeviceState deviceState(uint16_t status_word);
   /** returns the control word that will take device from state to next desired state */

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
@@ -64,6 +64,8 @@ protected:
   int fault_reset_command_interface_index_ = -1;
   bool last_fault_reset_command_ = false;
   double last_position_ = std::numeric_limits<double>::quiet_NaN();
+  bool temperature_fault_detected_ = false;
+  uint16_t error_code_ = 0;
 
   /** returns device state based upon the status_word */
   DeviceState deviceState(uint16_t status_word);

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 #include <limits>
+#include <atomic>
 
 #include "yaml-cpp/yaml.h"
 #include "ethercat_interface/ec_slave.hpp"
@@ -51,6 +52,9 @@ public:
   int8_t mode_of_operation_ = -1;
 
 protected:
+  // Global aggregated count of faulted instances (process-wide)
+  static std::atomic<int> num_faulted_;
+
   uint32_t counter_ = 0;
   uint16_t last_status_word_ = -1;
   uint16_t status_word_ = 0;

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
@@ -38,7 +38,7 @@ public:
   virtual ~EcCiA402Drive();
   /** Returns true if drive has reached "operation enabled" state.
    *  The transition through the state machine is handled automatically. */
-  bool initialized() override;
+  bool initialized() const;
 
   virtual void processData(size_t index, uint8_t * domain_address);
 

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
@@ -64,12 +64,15 @@ protected:
   bool initialized_ = false;
   bool auto_fault_reset_ = false;
   bool auto_state_transitions_ = true;
+  bool auto_state_transitions_cmd_ = false;
   bool fault_reset_ = false;
   int fault_reset_command_interface_index_ = -1;
   bool last_fault_reset_command_ = false;
   double last_position_ = std::numeric_limits<double>::quiet_NaN();
   bool temperature_fault_detected_ = false;
   uint16_t error_code_ = 0;
+  int auto_state_cmd_index_ = -1;
+  bool last_auto_state_cmd_ = false;
 
   // Quick stop behavior controls
   bool exclude_from_global_quick_stop_ = false; // Do not propagate this drive's faults globally if true

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -58,7 +58,7 @@ void EcCiA402Drive::processData(size_t index, uint8_t *domain_address)
                 uint16_t cw = transition(state_, pdo_channels_info_[index].ec_read(domain_address));
                 // If any instance is faulted, force quick-stop only on non-faulted drives
                 if (num_faulted_.load(std::memory_order_relaxed) > 0) {
-                    if ((error_code_ == 0) && ((status_word_ & 0x07) == 0x07)) { // & status 7 = 7 (first 3 bits always 1)
+                    if (error_code_ == 0) { // && ((status_word_ & 0x07) == 0x07)) { // & status 7 = 7 (first 3 bits always 1) this induces weird sound while resetting error!!! 
                         // Clear bit7 and bit0, set bit2 and bit1 (CiA-402 Shutdown)
                         cw = (cw & 0x7E) | 0x06;   // same as (cw & 0b01111110) | 0b00000110
                         // safe quick-stop path for healthy drives, this is writing 6 to the actuators. @babak 

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -91,21 +91,11 @@ void EcCiA402Drive::processData(size_t index, uint8_t *domain_address)
     if (pdo_channels_info_[index].index == CiA402D_TPDO_POSITION)
     {
         double current_position = pdo_channels_info_[index].last_value;
-        // Initialize last_position_ if it hasn't been set yet (first time)
-        if (std::isnan(last_position_))
+        // Initialize last_position_ if it hasn't been set yet (first time) and the drive is operational
+        if (std::isnan(last_position_) && is_operational_)
         {
             last_position_ = current_position;
             std::cout << "Position initialized: " << last_position_ << std::endl;
-        }
-        else
-        {
-            // Only update last_position_ if the change is significant (prevents drifting)
-            double position_threshold = 0.0001; // Adjust this threshold as needed
-            double change = std::abs(current_position - last_position_);
-            if (change > position_threshold)
-            {
-                last_position_ = current_position;
-            }
         }
     }
 

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -22,238 +22,310 @@ namespace ethercat_generic_plugins
 {
 
 EcCiA402Drive::EcCiA402Drive()
-: GenericEcSlave() {}
+    : GenericEcSlave()
+{
+}
 EcCiA402Drive::~EcCiA402Drive() {}
 
-bool EcCiA402Drive::initialized() const {return initialized_;}
+bool EcCiA402Drive::initialized() const { return initialized_; }
 
-void EcCiA402Drive::processData(size_t index, uint8_t * domain_address)
+void EcCiA402Drive::processData(size_t index, uint8_t *domain_address)
 {
-  // Special case: ControlWord
-  if (pdo_channels_info_[index].index == CiA402D_RPDO_CONTROLWORD) {
-    if (is_operational_) {
-      if (fault_reset_command_interface_index_ >= 0) {
-        if (command_interface_ptr_->at(fault_reset_command_interface_index_) == 0) {
-          last_fault_reset_command_ = false;
-        }
-        if (last_fault_reset_command_ == false &&
-          command_interface_ptr_->at(fault_reset_command_interface_index_) != 0 &&
-          !std::isnan(command_interface_ptr_->at(fault_reset_command_interface_index_)))
+    // Special case: ControlWord
+    if (pdo_channels_info_[index].index == CiA402D_RPDO_CONTROLWORD)
+    {
+        if (is_operational_)
         {
-          last_fault_reset_command_ = true;
-          fault_reset_ = true;
+            if (fault_reset_command_interface_index_ >= 0)
+            {
+                if (command_interface_ptr_->at(fault_reset_command_interface_index_) == 0)
+                {
+                    last_fault_reset_command_ = false;
+                }
+                if (last_fault_reset_command_ == false &&
+                    command_interface_ptr_->at(fault_reset_command_interface_index_) != 0 &&
+                    !std::isnan(command_interface_ptr_->at(fault_reset_command_interface_index_)))
+                {
+                    last_fault_reset_command_ = true;
+                    fault_reset_ = true;
+                }
+            }
+
+            if (auto_state_transitions_)
+            {
+                pdo_channels_info_[index].default_value =
+                    transition(state_, pdo_channels_info_[index].ec_read(domain_address));
+            }
         }
-      }
-
-      if (auto_state_transitions_) {
-        pdo_channels_info_[index].default_value = transition(
-          state_,
-          pdo_channels_info_[index].ec_read(domain_address));
-      }
     }
-  }
 
-  // setup current position as default position
-  if (pdo_channels_info_[index].index == CiA402D_RPDO_POSITION) {
-    if (mode_of_operation_display_ != ModeOfOperation::MODE_NO_MODE) {
-      pdo_channels_info_[index].default_value =
-        pdo_channels_info_[index].factor * last_position_ +
-        pdo_channels_info_[index].offset;
-    }
-    pdo_channels_info_[index].override_command =
-      (mode_of_operation_display_ != ModeOfOperation::MODE_CYCLIC_SYNC_POSITION) ? true : false;
-  }
-
-  // setup mode of operation
-  if (pdo_channels_info_[index].index == CiA402D_RPDO_MODE_OF_OPERATION) {
-    if (mode_of_operation_ >= 0 && mode_of_operation_ <= 10) {
-      pdo_channels_info_[index].default_value = mode_of_operation_;
-    }
-  }
-
-  pdo_channels_info_[index].ec_update(domain_address);
-
-  // get mode_of_operation_display_
-  if (pdo_channels_info_[index].index == CiA402D_TPDO_MODE_OF_OPERATION_DISPLAY) {
-    mode_of_operation_display_ = pdo_channels_info_[index].last_value;
-  }
-
-  if (pdo_channels_info_[index].index == CiA402D_TPDO_POSITION) {
-    last_position_ = pdo_channels_info_[index].last_value;
-  }
-
-  // Special case: StatusWord
-  if (pdo_channels_info_[index].index == CiA402D_TPDO_STATUSWORD) {
-    status_word_ = pdo_channels_info_[index].last_value;
-  }
-
-  // Special case: Error Code (0x603F)
-  if (pdo_channels_info_[index].index == CiA402D_TPDO_ERROR_CODE) {
-    uint16_t new_error_code = pdo_channels_info_[index].last_value;
-    if (new_error_code != error_code_) {
-      error_code_ = new_error_code;
-      std::cout << "Error Code: " << std::hex << error_code_ << std::dec << std::endl;
-      
-      // During startup, clear any stored temperature faults
-      if (counter_ < 100) {  // First 100 cycles = startup phase
-        if (error_code_ == 0x4110) {
-          std::cout << "Startup: Clearing stored temperature fault error code" << std::endl;
-          temperature_fault_detected_ = false;
+    // setup current position as default position
+    if (pdo_channels_info_[index].index == CiA402D_RPDO_POSITION)
+    {
+        if (mode_of_operation_display_ != ModeOfOperation::MODE_NO_MODE)
+        {
+            pdo_channels_info_[index].default_value =
+                pdo_channels_info_[index].factor * last_position_ + pdo_channels_info_[index].offset;
         }
-      }
-      // After startup, check for temperature fault using specific error code 0x4110
-      else if (error_code_ == 0x4110) {
-        temperature_fault_detected_ = true;
-        std::cout << "TEMPERATURE FAULT DETECTED (Error Code 0x4110) - Disabling automatic fault reset" << std::endl;
-      }
-      // Reset temperature fault flag when error code returns to 0 (no fault)
-      else if (error_code_ == 0x0) {
-        if (temperature_fault_detected_) {
-          temperature_fault_detected_ = false;
-          std::cout << "Temperature fault cleared - Automatic fault reset re-enabled" << std::endl;
+        pdo_channels_info_[index].override_command =
+            (mode_of_operation_display_ != ModeOfOperation::MODE_CYCLIC_SYNC_POSITION) ? true : false;
+    }
+
+    // setup mode of operation
+    if (pdo_channels_info_[index].index == CiA402D_RPDO_MODE_OF_OPERATION)
+    {
+        if (mode_of_operation_ >= 0 && mode_of_operation_ <= 10)
+        {
+            pdo_channels_info_[index].default_value = mode_of_operation_;
         }
-      }
     }
-  }
 
-  // CHECK FOR STATE CHANGE
-  if (index == all_channels_.size() - 1) {  // if last entry  in domain
-    if (status_word_ != last_status_word_) {
-      state_ = deviceState(status_word_);
-      if (state_ != last_state_) {
-        std::cout << "STATE: " << DEVICE_STATE_STR.at(state_)
-                  << " with status word :" << status_word_ << std::endl;
-      }
+    pdo_channels_info_[index].ec_update(domain_address);
+
+    // get mode_of_operation_display_
+    if (pdo_channels_info_[index].index == CiA402D_TPDO_MODE_OF_OPERATION_DISPLAY)
+    {
+        mode_of_operation_display_ = pdo_channels_info_[index].last_value;
     }
-    initialized_ = ((state_ == STATE_OPERATION_ENABLED) &&
-      (last_state_ == STATE_OPERATION_ENABLED)) ? true : false;
 
-    last_status_word_ = status_word_;
-    last_state_ = state_;
-    counter_++;
-  }
+    if (pdo_channels_info_[index].index == CiA402D_TPDO_POSITION)
+    {
+        double current_position = pdo_channels_info_[index].last_value;
+        // Initialize last_position_ if it hasn't been set yet (first time)
+        if (std::isnan(last_position_))
+        {
+            last_position_ = current_position;
+            std::cout << "Position initialized: " << last_position_ << std::endl;
+        }
+        else
+        {
+            // Only update last_position_ if the change is significant (prevents drifting)
+            double position_threshold = 0.0001; // Adjust this threshold as needed
+            double change = std::abs(current_position - last_position_);
+            if (change > position_threshold)
+            {
+                last_position_ = current_position;
+            }
+        }
+    }
+
+    // Special case: StatusWord
+    if (pdo_channels_info_[index].index == CiA402D_TPDO_STATUSWORD)
+    {
+        status_word_ = pdo_channels_info_[index].last_value;
+    }
+
+    // Special case: Error Code (0x603F)
+    if (pdo_channels_info_[index].index == CiA402D_TPDO_ERROR_CODE)
+    {
+        uint16_t new_error_code = pdo_channels_info_[index].last_value;
+        if (new_error_code != error_code_)
+        {
+            error_code_ = new_error_code;
+            std::cout << "Error Code: " << std::hex << error_code_ << std::dec << std::endl;
+
+            // During startup, clear any stored temperature faults
+            if (counter_ < 100)
+            { // First 100 cycles = startup phase
+                if (error_code_ == 0x4110)
+                {
+                    std::cout << "Startup: Clearing stored temperature fault error code" << std::endl;
+                    temperature_fault_detected_ = false;
+                }
+            }
+            // After startup, check for temperature fault using specific error code 0x4110
+            else if (error_code_ == 0x4110)
+            {
+                temperature_fault_detected_ = true;
+                std::cout << "TEMPERATURE FAULT DETECTED (Error Code 0x4110) - Disabling automatic fault reset"
+                          << std::endl;
+            }
+            // Reset temperature fault flag when error code returns to 0 (no fault)
+            else if (error_code_ == 0x0)
+            {
+                if (temperature_fault_detected_)
+                {
+                    temperature_fault_detected_ = false;
+                    std::cout << "Temperature fault cleared - Automatic fault reset re-enabled" << std::endl;
+                }
+            }
+        }
+    }
+
+    // CHECK FOR STATE CHANGE
+    if (index == all_channels_.size() - 1)
+    { // if last entry  in domain
+        if (status_word_ != last_status_word_)
+        {
+            state_ = deviceState(status_word_);
+            if (state_ != last_state_)
+            {
+                std::cout << "STATE: " << DEVICE_STATE_STR.at(state_) << " with status word :" << status_word_
+                          << std::endl;
+            }
+        }
+        initialized_ = ((state_ == STATE_OPERATION_ENABLED) && (last_state_ == STATE_OPERATION_ENABLED)) ? true : false;
+
+        last_status_word_ = status_word_;
+        last_state_ = state_;
+        counter_++;
+    }
 }
 
-bool EcCiA402Drive::setupSlave(
-  std::unordered_map<std::string, std::string> slave_paramters,
-  std::vector<double> * state_interface,
-  std::vector<double> * command_interface)
+bool EcCiA402Drive::setupSlave(std::unordered_map<std::string, std::string> slave_paramters,
+                               std::vector<double> *state_interface, std::vector<double> *command_interface)
 {
-  state_interface_ptr_ = state_interface;
-  command_interface_ptr_ = command_interface;
-  paramters_ = slave_paramters;
+    state_interface_ptr_ = state_interface;
+    command_interface_ptr_ = command_interface;
+    paramters_ = slave_paramters;
 
-  if (paramters_.find("slave_config") != paramters_.end()) {
-    if (!setup_from_config_file(paramters_["slave_config"])) {
-      return false;
+    if (paramters_.find("slave_config") != paramters_.end())
+    {
+        if (!setup_from_config_file(paramters_["slave_config"]))
+        {
+            return false;
+        }
     }
-  } else {
-    std::cerr << "EcCiA402Drive: failed to find 'slave_config' tag in URDF." << std::endl;
-    return false;
-  }
+    else
+    {
+        std::cerr << "EcCiA402Drive: failed to find 'slave_config' tag in URDF." << std::endl;
+        return false;
+    }
 
-  setup_interface_mapping();
-  setup_syncs();
+    setup_interface_mapping();
+    setup_syncs();
 
-  if (paramters_.find("mode_of_operation") != paramters_.end()) {
-    mode_of_operation_ = std::stod(paramters_["mode_of_operation"]);
-  }
+    if (paramters_.find("mode_of_operation") != paramters_.end())
+    {
+        mode_of_operation_ = std::stod(paramters_["mode_of_operation"]);
+    }
 
-  if (paramters_.find("command_interface/reset_fault") != paramters_.end()) {
-    fault_reset_command_interface_index_ = std::stoi(paramters_["command_interface/reset_fault"]);
-  }
+    if (paramters_.find("command_interface/reset_fault") != paramters_.end())
+    {
+        fault_reset_command_interface_index_ = std::stoi(paramters_["command_interface/reset_fault"]);
+    }
 
-  return true;
+    return true;
 }
 
 bool EcCiA402Drive::setup_from_config(YAML::Node drive_config)
 {
-  if (!GenericEcSlave::setup_from_config(drive_config)) {return false;}
-  // additional configuration parameters for CiA402 Drives
-  if (drive_config["auto_fault_reset"]) {
-    auto_fault_reset_ = drive_config["auto_fault_reset"].as<bool>();
-  }
-  if (drive_config["auto_state_transitions"]) {
-    auto_state_transitions_ = drive_config["auto_state_transitions"].as<bool>();
-  }
-  return true;
+    if (!GenericEcSlave::setup_from_config(drive_config))
+    {
+        return false;
+    }
+    // additional configuration parameters for CiA402 Drives
+    if (drive_config["auto_fault_reset"])
+    {
+        auto_fault_reset_ = drive_config["auto_fault_reset"].as<bool>();
+    }
+    if (drive_config["auto_state_transitions"])
+    {
+        auto_state_transitions_ = drive_config["auto_state_transitions"].as<bool>();
+    }
+    return true;
 }
 
 bool EcCiA402Drive::setup_from_config_file(std::string config_file)
 {
-  // Read drive configuration from YAML file
-  try {
-    slave_config_ = YAML::LoadFile(config_file);
-  } catch (const YAML::ParserException & ex) {
-    std::cerr << "EcCiA402Drive: failed to load drive configuration: " << ex.what() << std::endl;
-    return false;
-  } catch (const YAML::BadFile & ex) {
-    std::cerr << "EcCiA402Drive: failed to load drive configuration: " << ex.what() << std::endl;
-    return false;
-  }
-  if (!setup_from_config(slave_config_)) {
-    return false;
-  }
-  return true;
+    // Read drive configuration from YAML file
+    try
+    {
+        slave_config_ = YAML::LoadFile(config_file);
+    }
+    catch (const YAML::ParserException &ex)
+    {
+        std::cerr << "EcCiA402Drive: failed to load drive configuration: " << ex.what() << std::endl;
+        return false;
+    }
+    catch (const YAML::BadFile &ex)
+    {
+        std::cerr << "EcCiA402Drive: failed to load drive configuration: " << ex.what() << std::endl;
+        return false;
+    }
+    if (!setup_from_config(slave_config_))
+    {
+        return false;
+    }
+    return true;
 }
 
 /** returns device state based upon the status_word */
 DeviceState EcCiA402Drive::deviceState(uint16_t status_word)
 {
-  if ((status_word & 0b01001111) == 0b00000000) {
-    return STATE_NOT_READY_TO_SWITCH_ON;
-  } else if ((status_word & 0b01001111) == 0b01000000) {
-    return STATE_SWITCH_ON_DISABLED;
-  } else if ((status_word & 0b01101111) == 0b00100001) {
-    return STATE_READY_TO_SWITCH_ON;
-  } else if ((status_word & 0b01101111) == 0b00100011) {
-    return STATE_SWITCH_ON;
-  } else if ((status_word & 0b01101111) == 0b00100111) {
-    return STATE_OPERATION_ENABLED;
-  } else if ((status_word & 0b01101111) == 0b00000111) {
-    return STATE_QUICK_STOP_ACTIVE;
-  } else if ((status_word & 0b01001111) == 0b00001111) {
-    return STATE_FAULT_REACTION_ACTIVE;
-  } else if ((status_word & 0b01001111) == 0b00001000) {
-    return STATE_FAULT;
-  }
-  return STATE_UNDEFINED;
+    if ((status_word & 0b01001111) == 0b00000000)
+    {
+        return STATE_NOT_READY_TO_SWITCH_ON;
+    }
+    else if ((status_word & 0b01001111) == 0b01000000)
+    {
+        return STATE_SWITCH_ON_DISABLED;
+    }
+    else if ((status_word & 0b01101111) == 0b00100001)
+    {
+        return STATE_READY_TO_SWITCH_ON;
+    }
+    else if ((status_word & 0b01101111) == 0b00100011)
+    {
+        return STATE_SWITCH_ON;
+    }
+    else if ((status_word & 0b01101111) == 0b00100111)
+    {
+        return STATE_OPERATION_ENABLED;
+    }
+    else if ((status_word & 0b01101111) == 0b00000111)
+    {
+        return STATE_QUICK_STOP_ACTIVE;
+    }
+    else if ((status_word & 0b01001111) == 0b00001111)
+    {
+        return STATE_FAULT_REACTION_ACTIVE;
+    }
+    else if ((status_word & 0b01001111) == 0b00001000)
+    {
+        return STATE_FAULT;
+    }
+    return STATE_UNDEFINED;
 }
 
 /** returns the control word that will take device from state to next desired state */
 uint16_t EcCiA402Drive::transition(DeviceState state, uint16_t control_word)
 {
-  switch (state) {
-    case STATE_START:                     // -> STATE_NOT_READY_TO_SWITCH_ON (automatic)
-      return control_word;
-    case STATE_NOT_READY_TO_SWITCH_ON:    // -> STATE_SWITCH_ON_DISABLED (automatic)
-      return control_word;
-    case STATE_SWITCH_ON_DISABLED:        // -> STATE_READY_TO_SWITCH_ON
-      return (control_word & 0b01111110) | 0b00000110;
-    case STATE_READY_TO_SWITCH_ON:        // -> STATE_SWITCH_ON
-      return (control_word & 0b01110111) | 0b00000111;
-    case STATE_SWITCH_ON:                 // -> STATE_OPERATION_ENABLED
-      return (control_word & 0b01111111) | 0b00001111;
-    case STATE_OPERATION_ENABLED:         // -> GOOD
-      return control_word;
-    case STATE_QUICK_STOP_ACTIVE:         // -> STATE_OPERATION_ENABLED
-      return (control_word & 0b01111111) | 0b00001111;
-    case STATE_FAULT_REACTION_ACTIVE:     // -> STATE_FAULT (automatic)
-      return control_word;
-    case STATE_FAULT:                     // -> STATE_SWITCH_ON_DISABLED
-      if ((auto_fault_reset_ || fault_reset_) && !temperature_fault_detected_) {
-        fault_reset_ = false;
-        return (control_word & 0b11111111) | 0b10000000;     // automatic reset
-      } else {
+    switch (state)
+    {
+    case STATE_START: // -> STATE_NOT_READY_TO_SWITCH_ON (automatic)
         return control_word;
-      }
+    case STATE_NOT_READY_TO_SWITCH_ON: // -> STATE_SWITCH_ON_DISABLED (automatic)
+        return control_word;
+    case STATE_SWITCH_ON_DISABLED: // -> STATE_READY_TO_SWITCH_ON
+        return (control_word & 0b01111110) | 0b00000110;
+    case STATE_READY_TO_SWITCH_ON: // -> STATE_SWITCH_ON
+        return (control_word & 0b01110111) | 0b00000111;
+    case STATE_SWITCH_ON: // -> STATE_OPERATION_ENABLED
+        return (control_word & 0b01111111) | 0b00001111;
+    case STATE_OPERATION_ENABLED: // -> GOOD
+        return control_word;
+    case STATE_QUICK_STOP_ACTIVE: // -> STATE_OPERATION_ENABLED
+        return (control_word & 0b01111111) | 0b00001111;
+    case STATE_FAULT_REACTION_ACTIVE: // -> STATE_FAULT (automatic)
+        return control_word;
+    case STATE_FAULT: // -> STATE_SWITCH_ON_DISABLED
+        if ((auto_fault_reset_ || fault_reset_) && !temperature_fault_detected_)
+        {
+            fault_reset_ = false;
+            return (control_word & 0b11111111) | 0b10000000; // automatic reset
+        }
+        else
+        {
+            return control_word;
+        }
     default:
-      break;
-  }
-  return control_word;
+        break;
+    }
+    return control_word;
 }
 
-}  // namespace ethercat_generic_plugins
+} // namespace ethercat_generic_plugins
 
 #include <pluginlib/class_list_macros.hpp>
 

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -27,9 +27,7 @@ EcCiA402Drive::EcCiA402Drive()
 }
 EcCiA402Drive::~EcCiA402Drive() {}
 
-bool EcCiA402Drive::initialized() { 
-    return initialized_; 
-}
+bool EcCiA402Drive::initialized() const { return initialized_; }
 
 void EcCiA402Drive::processData(size_t index, uint8_t *domain_address)
 {

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -58,7 +58,7 @@ void EcCiA402Drive::processData(size_t index, uint8_t *domain_address)
                 uint16_t cw = transition(state_, pdo_channels_info_[index].ec_read(domain_address));
                 // If any instance is faulted, force quick-stop only on non-faulted drives
                 if (num_faulted_.load(std::memory_order_relaxed) > 0) {
-                    if (error_code_ == 0) { // && ((status_word_ & 0x07) == 0x07)) { // & status 7 = 7 (first 3 bits always 1) this induces weird sound while resetting error!!! 
+                    if (error_code_ == 0) {  
                         // Clear bit7 and bit0, set bit2 and bit1 (CiA-402 Shutdown)
                         cw = (cw & 0x7E) | 0x06;   // same as (cw & 0b01111110) | 0b00000110
                         // safe quick-stop path for healthy drives, this is writing 6 to the actuators. @babak 

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -58,8 +58,10 @@ void EcCiA402Drive::processData(size_t index, uint8_t *domain_address)
                 uint16_t cw = transition(state_, pdo_channels_info_[index].ec_read(domain_address));
                 // If any instance is faulted, force quick-stop only on non-faulted drives
                 if (num_faulted_.load(std::memory_order_relaxed) > 0) {
-                    if (error_code_ == 0) {
-                        cw = (cw & 0b01111110) | 0b00000110; // safe quick-stop path for healthy drives
+                    if ((error_code_ == 0) && ((status_word_ & 0x07) == 0x07)) { // & status 7 = 7 (first 3 bits always 1)
+                        // Clear bit7 and bit0, set bit2 and bit1 (CiA-402 Shutdown)
+                        cw = (cw & 0x7E) | 0x06;   // same as (cw & 0b01111110) | 0b00000110
+                        // safe quick-stop path for healthy drives, this is writing 6 to the actuators. @babak 
                     }
                     // If this drive is faulted (error_code_ != 0), do not override so reset can proceed
                 }

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -27,7 +27,9 @@ EcCiA402Drive::EcCiA402Drive()
 }
 EcCiA402Drive::~EcCiA402Drive() {}
 
-bool EcCiA402Drive::initialized() const { return initialized_; }
+bool EcCiA402Drive::initialized() { 
+    return initialized_; 
+}
 
 void EcCiA402Drive::processData(size_t index, uint8_t *domain_address)
 {

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -67,6 +67,20 @@ void EcCiA402Drive::processData(size_t index, uint8_t *domain_address)
                 }
                 pdo_channels_info_[index].default_value = cw;
             }
+            if (auto_state_cmd_index_ >= 0)
+            {
+                if (command_interface_ptr_->at(auto_state_cmd_index_) == 0)
+                {
+                    last_auto_state_cmd_ = false;
+                }
+                if (last_auto_state_cmd_ == false &&
+                    command_interface_ptr_->at(auto_state_cmd_index_) != 0 &&
+                    !std::isnan(command_interface_ptr_->at(auto_state_cmd_index_)))
+                {
+                    last_auto_state_cmd_ = true;
+                    auto_state_transitions_cmd_ = true;
+                }
+            }
         }
     }
 
@@ -218,6 +232,11 @@ bool EcCiA402Drive::setupSlave(std::unordered_map<std::string, std::string> slav
         fault_reset_command_interface_index_ = std::stoi(paramters_["command_interface/reset_fault"]);
     }
 
+    if (paramters_.find("command_interface/auto_state_transitions") != paramters_.end())
+    {
+        auto_state_cmd_index_ = std::stoi(paramters_["command_interface/auto_state_transitions"]);
+    }
+
     return true;
 }
 
@@ -319,7 +338,14 @@ uint16_t EcCiA402Drive::transition(DeviceState state, uint16_t control_word)
     case STATE_READY_TO_SWITCH_ON: // -> STATE_SWITCH_ON
         return (control_word & 0b01110111) | 0b00000111;
     case STATE_SWITCH_ON: // -> STATE_OPERATION_ENABLED
+        if (auto_state_transitions_cmd_)
+        {
         return (control_word & 0b01111111) | 0b00001111;
+        }
+        else
+        {
+            return (control_word & 0b01110111) | 0b00000111;
+        }
     case STATE_OPERATION_ENABLED: // -> GOOD
         return control_word;
     case STATE_QUICK_STOP_ACTIVE: // -> STATE_OPERATION_ENABLED

--- a/ethercat_interface/CMakeLists.txt
+++ b/ethercat_interface/CMakeLists.txt
@@ -11,9 +11,12 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 
 # EtherLab
-set(ETHERLAB_DIR /usr/local/etherlab)
+if(DEFINED ENV{CONDA_PREFIX})
+  set(ETHERLAB_DIR $ENV{CONDA_PREFIX}/usr/local/etherlab)
+else()
+  set(ETHERLAB_DIR /usr/local/etherlab)
+endif()
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 find_library(ETHERCAT_LIB ethercat HINTS ${ETHERLAB_DIR}/lib)
 
 ament_export_include_directories(

--- a/ethercat_interface/include/ethercat_interface/ec_master.hpp
+++ b/ethercat_interface/include/ethercat_interface/ec_master.hpp
@@ -90,6 +90,8 @@ public:
   void readData(uint32_t domain = 0);
   void writeData(uint32_t domain = 0);
 
+  bool isValid() const { return master_ != NULL; }
+
 private:
   /** true if running */
   volatile bool running_ = false;

--- a/ethercat_interface/include/ethercat_interface/ec_slave.hpp
+++ b/ethercat_interface/include/ethercat_interface/ec_slave.hpp
@@ -41,6 +41,7 @@ public:
   virtual const ec_sync_info_t * syncs() {return NULL;}
   virtual bool initialized() {return true;}
   virtual void set_state_is_operational(bool value) {is_operational_ = value;}
+  bool is_operational() const { return is_operational_; }
   /** Assign activate DC synchronization. return activate word*/
   virtual int assign_activate_dc_sync() {return 0x00;}
   /** number of elements in the syncs array. */

--- a/ethercat_interface/src/ec_master.cpp
+++ b/ethercat_interface/src/ec_master.cpp
@@ -74,6 +74,10 @@ EcMaster::~EcMaster()
       delete domain.second;
     }
   }
+  if (master_ != NULL) {
+    ecrt_release_master(master_);
+    master_ = NULL;
+  }
 }
 
 void EcMaster::addSlave(uint16_t alias, uint16_t position, EcSlave * slave)

--- a/ethercat_manager/CMakeLists.txt
+++ b/ethercat_manager/CMakeLists.txt
@@ -6,9 +6,12 @@ find_package(rclcpp REQUIRED)
 find_package(ethercat_msgs REQUIRED)
 
 # EtherLab
-set(ETHERLAB_DIR /usr/local/etherlab)
+if(DEFINED ENV{CONDA_PREFIX})
+  set(ETHERLAB_DIR $ENV{CONDA_PREFIX}/usr/local/etherlab)
+else()
+  set(ETHERLAB_DIR /usr/local/etherlab)
+endif()
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 find_library(ETHERCAT_LIB ethercat HINTS ${ETHERLAB_DIR}/lib)
 
 ament_export_include_directories(

--- a/ethercat_manager/include/ethercat_manager/ec_master_async.hpp
+++ b/ethercat_manager/include/ethercat_manager/ec_master_async.hpp
@@ -21,6 +21,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <stdio.h>
+#include <unistd.h>
 #include <ecrt.h>
 #include <errno.h>
 #include <sstream>

--- a/ethercat_manager/include/ethercat_manager/ec_master_async_io.hpp
+++ b/ethercat_manager/include/ethercat_manager/ec_master_async_io.hpp
@@ -20,7 +20,7 @@
 #define EC_IOR(nr, type)  _IOR(EC_IOCTL_TYPE, nr, type)
 #define EC_IOW(nr, type)  _IOW(EC_IOCTL_TYPE, nr, type)
 #define EC_IOWR(nr, type)  _IOWR(EC_IOCTL_TYPE, nr, type)
-#define EC_IOCTL_VERSION_MAGIC 31
+#define EC_IOCTL_VERSION_MAGIC 37 // ioctl() version magic is matching: /dev/EtherCAT0: 37, ethercat tool: 37
 #define EC_IOCTL_MODULE  EC_IOR(0x00, ec_ioctl_module_t)
 #define EC_IOCTL_SLAVE_SDO_UPLOAD  EC_IOWR(0x0e, ec_ioctl_slave_sdo_upload_t)
 #define EC_IOCTL_SLAVE_SDO_DOWNLOAD  EC_IOWR(0x0f, ec_ioctl_slave_sdo_download_t)

--- a/ethercat_manager/src/ethercat_sdo_srv_server.cpp
+++ b/ethercat_manager/src/ethercat_sdo_srv_server.cpp
@@ -54,7 +54,7 @@ void upload(
 
   EcMasterAsync master(request->master_id);
   try {
-    master.open(EcMasterAsync::Read);
+    master.open(EcMasterAsync::ReadWrite);
   } catch (MasterException & e) {
     return_stream << e.what();
     response->success = false;


### PR DESCRIPTION
`master_` member of `EthercatDriver` class is static and ignored any masted_id values ​​in config except default 0

Changes:
- `master_` changed to unique_ptr and initialized with `master_id` value from config (or 0 by default) 

Tests:
- tested with two masters with two ZeroErr motors connected as etherCAT slaves to different masters (0 and 1) and controlled simultaneously by ROS2 JointTrajectoryController