### PR TITLE
Transition from ament_target_dependencies to target_link_libraries

### DIFF
--- a/ethercat_driver/CMakeLists.txt
+++ b/ethercat_driver/CMakeLists.txt
@@ -31,13 +31,12 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  hardware_interface
-  pluginlib
-  rclcpp
-  rclcpp_lifecycle
-  ethercat_interface
+target_link_libraries(${PROJECT_NAME}
+  hardware_interface::hardware_interface
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ethercat_interface::ethercat_interface
   yaml_cpp_vendor
 )
 
@@ -135,15 +134,11 @@ if(BUILD_TESTING)
   target_link_libraries(test_ethercat_safety_driver
     ${PROJECT_NAME}
     ${YAML_CPP_LIBRARIES}
-  )
-
-  ament_target_dependencies(test_ethercat_safety_driver
-    hardware_interface
-    pluginlib
-    rclcpp
-    rclcpp_lifecycle
-    ethercat_interface
-    yaml_cpp_vendor
+    hardware_interface::hardware_interface
+    pluginlib::pluginlib
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
+    ethercat_interface::ethercat_interface
   )
 
   # Add yaml-cpp to test target as well

--- a/ethercat_driver/CMakeLists.txt
+++ b/ethercat_driver/CMakeLists.txt
@@ -31,13 +31,16 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
+# Add yaml include dirs
+target_include_directories(${PROJECT_NAME} PRIVATE ${YAML_CPP_INCLUDE_DIRS})
+
 target_link_libraries(${PROJECT_NAME}
   hardware_interface::hardware_interface
   pluginlib::pluginlib
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   ethercat_interface::ethercat_interface
-  yaml_cpp_vendor
+  ${YAML_CPP_LIBRARIES}
 )
 
 # Explicitly link yaml-cpp

--- a/ethercat_driver/package.xml
+++ b/ethercat_driver/package.xml
@@ -15,7 +15,6 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>ethercat_interface</depend>
   <depend>yaml_cpp_vendor</depend>
-  <depend>yaml-cpp</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/ethercat_driver_ros2/sphinx/developer_guide/new_plugin.rst
+++ b/ethercat_driver_ros2/sphinx/developer_guide/new_plugin.rst
@@ -137,10 +137,9 @@ Modify your :code:`CMakeLists.txt` file so that it looks like this:
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
-  ament_target_dependencies(
-    ${PROJECT_NAME}
-    "ethercat_interface"
-    "pluginlib"
+  target_link_libraries(${PROJECT_NAME} PUBLIC
+    ethercat_interface::ethercat_interface
+    pluginlib::pluginlib
   )
   pluginlib_export_plugin_description_file(ethercat_interface ethercat_plugins.xml)
   install(

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/CMakeLists.txt
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/CMakeLists.txt
@@ -18,20 +18,28 @@ find_package(ethercat_interface REQUIRED)
 find_package(ethercat_generic_slave REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
-find_package(yaml-cpp REQUIRED)
+
+# Find system yaml-cpp for proper linking
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
 
 file(GLOB_RECURSE PLUGINS_SRC src/*.cpp)
 add_library(${PROJECT_NAME} ${PLUGINS_SRC})
 target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+# Add compile options required by the yaml_cpp_vendor
+target_compile_options(${PROJECT_NAME} PRIVATE ${YAML_CPP_CFLAGS_OTHER})
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include>
+)
+# Add yaml include dirs
+target_include_directories(${PROJECT_NAME} PRIVATE ${YAML_CPP_INCLUDE_DIRS})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
   ethercat_interface::ethercat_interface
   ethercat_generic_slave::ethercat_generic_slave
   pluginlib::pluginlib
-  yaml-cpp
+  ${YAML_CPP_LIBRARIES}
 )
 
 pluginlib_export_plugin_description_file(ethercat_interface ethercat_plugins.xml)

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/CMakeLists.txt
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/CMakeLists.txt
@@ -26,15 +26,11 @@ target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)  # Require C
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-target_link_libraries(${PROJECT_NAME} yaml-cpp)
 
-
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  ethercat_interface
-  ethercat_generic_slave
-  pluginlib
-  yaml_cpp_vendor
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ethercat_interface::ethercat_interface
+  ethercat_generic_slave::ethercat_generic_slave
+  pluginlib::pluginlib
   yaml-cpp
 )
 

--- a/ethercat_generic_plugins/ethercat_generic_slave/CMakeLists.txt
+++ b/ethercat_generic_plugins/ethercat_generic_slave/CMakeLists.txt
@@ -29,13 +29,9 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies( ${PROJECT_NAME}
-  ethercat_interface
-  pluginlib
-  yaml_cpp_vendor
-  yaml-cpp
-)
 target_link_libraries(${PROJECT_NAME}
+  ethercat_interface::ethercat_interface
+  pluginlib::pluginlib
   yaml-cpp
 )
 
@@ -73,7 +69,10 @@ if(BUILD_TESTING)
     test_generic_ec_slave
     test/test_generic_ec_slave.cpp
   )
-  target_include_directories(test_generic_ec_slave PRIVATE include)
+  target_include_directories(test_generic_ec_slave PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+  )
   target_link_libraries(test_generic_ec_slave
     ${PROJECT_NAME}
   )

--- a/ethercat_generic_plugins/ethercat_generic_slave/CMakeLists.txt
+++ b/ethercat_generic_plugins/ethercat_generic_slave/CMakeLists.txt
@@ -17,7 +17,10 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(ethercat_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
-find_package(yaml-cpp REQUIRED)
+
+# Find system yaml-cpp for proper linking
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
 
 file(GLOB_RECURSE PLUGINS_SRC src/*.cpp)
 
@@ -28,11 +31,12 @@ target_compile_features(${PROJECT_NAME} PUBLIC c_std_99 cxx_std_17)  # Require C
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
+  ${YAML_CPP_INCLUDE_DIRS}
 )
 target_link_libraries(${PROJECT_NAME}
   ethercat_interface::ethercat_interface
   pluginlib::pluginlib
-  yaml-cpp
+  ${YAML_CPP_LIBRARIES}
 )
 
 pluginlib_export_plugin_description_file(ethercat_interface ethercat_plugins.xml)

--- a/ethercat_interface/CMakeLists.txt
+++ b/ethercat_interface/CMakeLists.txt
@@ -23,11 +23,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 find_library(ETHERCAT_LIB ethercat HINTS ${ETHERLAB_DIR}/lib)
 
-ament_export_include_directories(
-  include
-  ${ETHERLAB_DIR}/include
-)
-
 add_library(
   ${PROJECT_NAME}
   SHARED
@@ -37,28 +32,29 @@ add_library(
   src/ec_pdo_group_interface_channel_manager.cpp
 )
 
-target_include_directories(
-  ${PROJECT_NAME}
-  PRIVATE
-  include
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
   ${ETHERLAB_DIR}/include
 )
 
-target_link_libraries(${PROJECT_NAME} ${ETHERCAT_LIB})
-
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  rclcpp
+target_link_libraries(${PROJECT_NAME}
+  ${ETHERCAT_LIB}
+  rclcpp::rclcpp
 )
 
 # INSTALL
 install(
   TARGETS ${PROJECT_NAME}
-  DESTINATION lib
+  EXPORT export_${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
 )
+
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
@@ -83,13 +79,7 @@ if(BUILD_TESTING)
 endif()
 
 ## EXPORTS
-ament_export_include_directories(
-  include
-)
-ament_export_libraries(
-  ${PROJECT_NAME}
-  ${ETHERCAT_LIBRARY}
-)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   rclcpp
 )

--- a/ethercat_interface/CMakeLists.txt
+++ b/ethercat_interface/CMakeLists.txt
@@ -62,7 +62,9 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
 
   find_package(yaml_cpp_vendor REQUIRED)
-  find_package(yaml-cpp REQUIRED)
+  # Find system yaml-cpp for proper linking
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
 
   ament_lint_auto_find_test_dependencies()
 
@@ -71,11 +73,16 @@ if(BUILD_TESTING)
     test_ec_pdo_channel_manager
     test/test_ec_pdo_channel_manager.cpp
   )
-  target_include_directories(test_ec_pdo_channel_manager PRIVATE include ${ETHERLAB_DIR}/include)
+  target_include_directories(test_ec_pdo_channel_manager PRIVATE
+    include
+    ${ETHERLAB_DIR}/include
+    ${YAML_CPP_INCLUDE_DIRS}
+  )
 
   target_link_libraries(test_ec_pdo_channel_manager
     ${PROJECT_NAME}
-    yaml-cpp)
+    ${YAML_CPP_LIBRARIES}
+  )
 endif()
 
 ## EXPORTS

--- a/ethercat_manager/CMakeLists.txt
+++ b/ethercat_manager/CMakeLists.txt
@@ -31,8 +31,11 @@ target_include_directories(
   include
   ${ETHERLAB_DIR}/include
 )
-target_link_libraries(ethercat_sdo_srv_server ${ETHERCAT_LIB})
-ament_target_dependencies(ethercat_sdo_srv_server rclcpp ethercat_msgs)
+target_link_libraries(ethercat_sdo_srv_server PUBLIC
+  ${ETHERCAT_LIB}
+  rclcpp::rclcpp
+  ${ethercat_msgs_TARGETS}
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
While using this repo with ROS Rolling Ridley, I have removed all uses of ament_target_dependencies, since it is now deprecated. I haven't tested this on anything but Rolling, and I'm no CMake wizard, but I thought I would create a PR to see if this might be useful. Let me know if there are any issues, and I'll be glad to try and address them as best I can.