### PR TITLE
Change CI workflow branch from 'main' to 'jazzy'

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -19,5 +19,5 @@ RUN mkdir ec_dev && cd ec_dev && \
     make && make install
 # Ros2 control interfaces
 RUN apt install -y ros-${ROS_DISTRO}-control-msgs ros-${ROS_DISTRO}-control-toolbox ros-${ROS_DISTRO}-hardware-interface ros-${ROS_DISTRO}-controller-interface
-# Ros formating tools
+# Ros formatting tools
 RUN apt install -y ros-${ROS_DISTRO}-ament-clang-format

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -2,6 +2,6 @@
 Provides a basic preconfigured docker container for development purposes. To use it, make sure you have [Docker](https://docs.docker.com/get-docker/) installed, then build and run the image :
 
 ```shell
-$ docker build --tag ethercat_driver:humble --file .docker/Dockerfile .
-$ docker run -it --privileged --network=host ethercat_driver:humble
+$ docker build --tag ethercat_driver:jazzy --file .docker/Dockerfile .
+$ docker run -it --privileged --network=host ethercat_driver:jazzy
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,29 +25,29 @@ jobs:
       - name: Build Docker Image
         uses: docker/build-push-action@v5
         with:
-          tags: ethercat_driver_ros2:humble
+          tags: ethercat_driver_ros2:jazzy
           file: .docker/Dockerfile
           push: false
 
       - name: Build
         uses: addnab/docker-run-action@v3
         with:
-          image: ethercat_driver_ros2:humble
+          image: ethercat_driver_ros2:jazzy
           options: -v ${{github.workspace}}/:/ros/
           run: |
             cd /ros
-            . /opt/ros/humble/setup.sh
+            . /opt/ros/jazzy/setup.sh
             rosdep install --ignore-src --from-paths . -y -r && \
             colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 
       - name: Tests
         uses: addnab/docker-run-action@v3
         with:
-          image: ethercat_driver_ros2:humble
+          image: ethercat_driver_ros2:jazzy
           options: -v ${{github.workspace}}/:/ros/
           run: |
             cd /ros
-            . /opt/ros/humble/setup.sh
+            . /opt/ros/jazzy/setup.sh
             rosdep install --ignore-src --from-paths . -y -r && \
             colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
             colcon test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ jazzy ]
   pull_request:
-    branches: [ main ]
+    branches: [ jazzy ]
 jobs:
   CI:
     permissions:


### PR DESCRIPTION
Make sure the test are run on the `jazzy` branch.

@yguel Par contre, c'est pareil sur `humble`, sauf si ca a été modifié dans la branche `*-safety` que tu veux merger bientôt:

https://github.com/ICube-Robotics/ethercat_driver_ros2/blob/5882251f116bdebf1e248e2fce44528f82118066/.github/workflows/ci.yml#L2-L7