### PR TITLE
Allow using alias

### DIFF
--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -294,18 +294,17 @@ CallbackReturn EthercatDriver::on_activate(
   // configure SDO
   for (auto i = 0ul; i < ec_modules_.size(); i++) {
     for (auto & sdo : ec_modules_[i]->sdo_config) {
-      uint32_t abort_code;
       int ret = master_.configSlaveSdo(
+        std::stod(ec_module_parameters_[i]["alias"]),
         std::stod(ec_module_parameters_[i]["position"]),
-        sdo,
-        &abort_code
+        sdo
       );
       if (ret) {
         RCLCPP_INFO(
           rclcpp::get_logger("EthercatDriver"),
-          "Failed to download config SDO for module at position %s with Error: %d",
-          ec_module_parameters_[i]["position"].c_str(),
-          abort_code
+          "Failed to download config SDO for module with alias %s at position %s.",
+          ec_module_parameters_[i]["alias"].c_str(),
+          ec_module_parameters_[i]["position"].c_str()
         );
       }
     }

--- a/ethercat_interface/include/ethercat_interface/ec_master.hpp
+++ b/ethercat_interface/include/ethercat_interface/ec_master.hpp
@@ -43,7 +43,7 @@ public:
 
   /** \brief configure slave using SDO
     */
-  int configSlaveSdo(uint16_t slave_position, SdoConfigEntry sdo_config, uint32_t * abort_code);
+  int configSlaveSdo(uint16_t alias, uint16_t position, SdoConfigEntry sdo_config, uint32_t * abort_code);
 
   /** call after adding all slaves, and before update */
   bool activate();
@@ -158,6 +158,8 @@ private:
     EcSlave * slave = NULL;
     ec_slave_config_t * config = NULL;
     ec_slave_config_state_t config_state = {0, 0, 0};
+    uint16_t alias;
+    uint16_t position;
   };
 
   std::vector<SlaveInfo> slave_info_;

--- a/ethercat_interface/include/ethercat_interface/ec_master.hpp
+++ b/ethercat_interface/include/ethercat_interface/ec_master.hpp
@@ -43,7 +43,7 @@ public:
 
   /** \brief configure slave using SDO
     */
-  int configSlaveSdo(uint16_t alias, uint16_t position, SdoConfigEntry sdo_config, uint32_t * abort_code);
+  int configSlaveSdo(uint16_t alias, uint16_t position, SdoConfigEntry sdo_config);
 
   /** call after adding all slaves, and before update */
   bool activate();

--- a/ethercat_interface/src/ec_master.cpp
+++ b/ethercat_interface/src/ec_master.cpp
@@ -84,6 +84,8 @@ void EcMaster::addSlave(uint16_t alias, uint16_t position, EcSlave * slave)
 
   SlaveInfo slave_info;
   slave_info.slave = slave;
+  slave_info.alias = alias;
+  slave_info.position = position;
   slave_info.config = ecrt_master_slave_config(
     master_, alias, position,
     slave->vendor_id_,
@@ -149,20 +151,22 @@ void EcMaster::addSlave(uint16_t alias, uint16_t position, EcSlave * slave)
 }
 
 int EcMaster::configSlaveSdo(
-  uint16_t slave_position, SdoConfigEntry sdo_config,
+  uint16_t alias, uint16_t position,
+  SdoConfigEntry sdo_config,
   uint32_t * abort_code)
 {
   uint8_t buffer[8];
   sdo_config.buffer_write(buffer);
-  int ret = ecrt_master_sdo_download(
-    master_,
-    slave_position,
-    sdo_config.index,
-    sdo_config.sub_index,
-    buffer,
-    sdo_config.data_size(),
-    abort_code
-  );
+
+  auto slave = std::find_if(
+        slave_info_.begin(), slave_info_.end(),
+        [alias, position](const SlaveInfo &slave_info) {
+          return slave_info.alias == alias && slave_info.position == position;
+        }
+    );
+  int ret = ecrt_slave_config_sdo(
+          slave->config, sdo_config.index, sdo_config.sub_index, buffer,
+          sdo_config.data_size());
   return ret;
 }
 

--- a/ethercat_interface/src/ec_master.cpp
+++ b/ethercat_interface/src/ec_master.cpp
@@ -152,8 +152,7 @@ void EcMaster::addSlave(uint16_t alias, uint16_t position, EcSlave * slave)
 
 int EcMaster::configSlaveSdo(
   uint16_t alias, uint16_t position,
-  SdoConfigEntry sdo_config,
-  uint32_t * abort_code)
+  SdoConfigEntry sdo_config)
 {
   uint8_t buffer[8];
   sdo_config.buffer_write(buffer);


### PR DESCRIPTION
When using aliases, the SDO download fails and the motors are not configured. This PR adds support for alias when downloading the SDO.

Is the implementation of the suggestion made in https://github.com/ICube-Robotics/ethercat_driver_ros2/issues/119