### PR TITLE
Remove api version checks (ioctl_version_magic comparisons)

### DIFF
--- a/ethercat_manager/include/ethercat_manager/ec_master_async.hpp
+++ b/ethercat_manager/include/ethercat_manager/ec_master_async.hpp
@@ -81,13 +81,8 @@ public:
       }
 
       getModule(&module_data);
-      if (module_data.ioctl_version_magic != EC_IOCTL_VERSION_MAGIC) {
-        std::stringstream err;
-        err << "ioctl() version magic is differing: "
-            << deviceName.str() << ": " << module_data.ioctl_version_magic
-            << ", ethercat tool: " << EC_IOCTL_VERSION_MAGIC;
-        throw MasterException(err.str());
-      }
+      // No check for ioctl_version_magic here, check the documentation
+      // to see which version is supported.
       mcount_ = module_data.master_count;
     }
   }

--- a/ethercat_manager/include/ethercat_manager/ec_master_async_io.hpp
+++ b/ethercat_manager/include/ethercat_manager/ec_master_async_io.hpp
@@ -15,12 +15,13 @@
 #ifndef ETHERCAT_MANAGER__EC_MASTER_ASYNC_IO_HPP_
 #define ETHERCAT_MANAGER__EC_MASTER_ASYNC_IO_HPP_
 
+#include <cstdint>
+
 #define EC_IOCTL_TYPE 0xa4
 #define EC_IO(nr)  _IO(EC_IOCTL_TYPE, nr)
 #define EC_IOR(nr, type)  _IOR(EC_IOCTL_TYPE, nr, type)
 #define EC_IOW(nr, type)  _IOW(EC_IOCTL_TYPE, nr, type)
 #define EC_IOWR(nr, type)  _IOWR(EC_IOCTL_TYPE, nr, type)
-#define EC_IOCTL_VERSION_MAGIC 31
 #define EC_IOCTL_MODULE  EC_IOR(0x00, ec_ioctl_module_t)
 #define EC_IOCTL_SLAVE_SDO_UPLOAD  EC_IOWR(0x0e, ec_ioctl_slave_sdo_upload_t)
 #define EC_IOCTL_SLAVE_SDO_DOWNLOAD  EC_IOWR(0x0f, ec_ioctl_slave_sdo_download_t)


### PR DESCRIPTION
In order to avoid updating VERSION MAGIC NUMBER to follow igh ethercat master lib updates, from now on we rely on branch and tags to ensure compatibility. So far it has always been compatible (etherlab 1.5 and etherlab 1.6).