### PR TITLE
Improve cleanup and shutdown of modules and master

### DIFF
--- a/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
@@ -60,6 +60,9 @@ public:
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
 
   ETHERCAT_DRIVER_PUBLIC
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State & previous_state) override;
+
+  ETHERCAT_DRIVER_PUBLIC
   hardware_interface::return_type read(const rclcpp::Time &, const rclcpp::Duration &) override;
 
   ETHERCAT_DRIVER_PUBLIC

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -372,6 +372,17 @@ CallbackReturn EthercatDriver::on_deactivate(
   return CallbackReturn::SUCCESS;
 }
 
+CallbackReturn EthercatDriver::on_cleanup(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  ec_modules_.clear();
+
+  RCLCPP_INFO(
+    rclcpp::get_logger("EthercatDriver"), "System successfully cleaned up!");
+
+  return CallbackReturn::SUCCESS;
+}
+
 hardware_interface::return_type EthercatDriver::read(
   const rclcpp::Time & /*time*/,
   const rclcpp::Duration & /*period*/)

--- a/ethercat_interface/src/ec_master.cpp
+++ b/ethercat_interface/src/ec_master.cpp
@@ -74,6 +74,7 @@ EcMaster::~EcMaster()
       delete domain.second;
     }
   }
+  ecrt_release_master(master_);
 }
 
 void EcMaster::addSlave(uint16_t alias, uint16_t position, EcSlave * slave)


### PR DESCRIPTION
This change improves the shutdown behavior of the ros driver, where the slaves are cleared on cleanup and the master is released on it's destruction.

With this change, segfaults upon restart of the driver are avoided