### PR TITLE
Trigger CI on humble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ humble, main ]
   pull_request:
-    branches: [ main ]
+    branches: [ humble, main ]
 jobs:
   CI:
     permissions:


### PR DESCRIPTION
When the humble branch was created, the CI trigger was not modified (still `main`).