### PR TITLE
fix: defer `EcMaster` construction to respect `master_id` hardware parameter

### DIFF
--- a/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
@@ -83,7 +83,7 @@ private:
     "ethercat_interface", "ethercat_interface::EcSlave"};
 
   int control_frequency_;
-  ethercat_interface::EcMaster master_;
+  std::unique_ptr<ethercat_interface::EcMaster> master_;
   std::mutex ec_mutex_;
   bool activated_;
 };

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -33,6 +33,17 @@ CallbackReturn EthercatDriver::on_init(
   const std::lock_guard<std::mutex> lock(ec_mutex_);
   activated_ = false;
 
+  // Defer EcMaster construction so that master_id from hardware parameters
+  // is honoured (default inline member used master_id=0 for every instance).
+  int master_id = 0;
+  if (info_.hardware_parameters.count("master_id")) {
+    master_id = std::stoi(info_.hardware_parameters.at("master_id"));
+  }
+  master_ = std::make_unique<ethercat_interface::EcMaster>(master_id);
+  RCLCPP_INFO(
+    rclcpp::get_logger("EthercatDriver"),
+    "EcMaster constructed with master_id=%d", master_id);
+
   hw_joint_states_.resize(info_.joints.size());
   for (uint j = 0; j < info_.joints.size(); j++) {
     hw_joint_states_[j].resize(
@@ -282,10 +293,10 @@ CallbackReturn EthercatDriver::on_activate(
 
   // start EC and wait until state operative
 
-  master_.setCtrlFrequency(control_frequency_);
+  master_->setCtrlFrequency(control_frequency_);
 
   for (auto i = 0ul; i < ec_modules_.size(); i++) {
-    master_.addSlave(
+    master_->addSlave(
       std::stod(ec_module_parameters_[i]["alias"]),
       std::stod(ec_module_parameters_[i]["position"]),
       ec_modules_[i].get());
@@ -295,7 +306,7 @@ CallbackReturn EthercatDriver::on_activate(
   for (auto i = 0ul; i < ec_modules_.size(); i++) {
     for (auto & sdo : ec_modules_[i]->sdo_config) {
       uint32_t abort_code;
-      int ret = master_.configSlaveSdo(
+      int ret = master_->configSlaveSdo(
         std::stod(ec_module_parameters_[i]["position"]),
         sdo,
         &abort_code
@@ -311,7 +322,7 @@ CallbackReturn EthercatDriver::on_activate(
     }
   }
 
-  if (!master_.activate()) {
+  if (!master_->activate()) {
     RCLCPP_ERROR(rclcpp::get_logger("EthercatDriver"), "Activate EcMaster failed");
     return CallbackReturn::ERROR;
   }
@@ -328,7 +339,7 @@ CallbackReturn EthercatDriver::on_activate(
     clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &t, NULL);
     // update EtherCAT bus
 
-    master_.update();
+    master_->update();
     RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "updated!");
 
     // check if operational
@@ -340,7 +351,7 @@ CallbackReturn EthercatDriver::on_activate(
       running = false;
     }
     // calculate next shot. carry over nanoseconds into microseconds.
-    t.tv_nsec += master_.getInterval();
+    t.tv_nsec += master_->getInterval();
     while (t.tv_nsec >= 1000000000) {
       t.tv_nsec -= 1000000000;
       t.tv_sec++;
@@ -364,7 +375,7 @@ CallbackReturn EthercatDriver::on_deactivate(
   RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "Stopping ...please wait...");
 
   // stop EC and disconnect
-  master_.stop();
+  master_->stop();
 
   RCLCPP_INFO(
     rclcpp::get_logger("EthercatDriver"), "System successfully stopped!");
@@ -379,7 +390,7 @@ hardware_interface::return_type EthercatDriver::read(
   // try to lock so we can avoid blocking the read/write loop on the lock.
   const std::unique_lock<std::mutex> lock(ec_mutex_, std::try_to_lock);
   if (lock.owns_lock() && activated_) {
-    master_.readData();
+    master_->readData();
   }
   return hardware_interface::return_type::OK;
 }
@@ -391,7 +402,7 @@ hardware_interface::return_type EthercatDriver::write(
   // try to lock so we can avoid blocking the read/write loop on the lock.
   const std::unique_lock<std::mutex> lock(ec_mutex_, std::try_to_lock);
   if (lock.owns_lock() && activated_) {
-    master_.writeData();
+    master_->writeData();
   }
   return hardware_interface::return_type::OK;
 }

--- a/ethercat_interface/src/ec_master.cpp
+++ b/ethercat_interface/src/ec_master.cpp
@@ -74,6 +74,10 @@ EcMaster::~EcMaster()
       delete domain.second;
     }
   }
+  if (master_ != NULL) {
+    ecrt_release_master(master_);
+    master_ = NULL;
+  }
 }
 
 void EcMaster::addSlave(uint16_t alias, uint16_t position, EcSlave * slave)


### PR DESCRIPTION
Fixes #143

## Problem

`EcMaster` is default-constructed with `master_id=0` at plugin load time, before `on_init()` reads the `master_id` hardware parameter.

As a result, multi-master setups do not work correctly:

* every `EthercatDriver` instance requests master 0
* the second instance fails with "Device or resource busy"
* activation may then segfault due to a NULL master handle

Although `master_id` is documented in the user guide, it was not actually being honored during master reservation.

## Solution

This PR applies a minimal fix focused only on the multi-master issue.

### 1. Defer `EcMaster` construction

Replace the inline member:

```cpp
ethercat_interface::EcMaster master_;
```

with:

```cpp
std::unique_ptr<ethercat_interface::EcMaster> master_;
```

Then construct it in `on_init()` after reading `master_id` from hardware parameters:

```cpp
int master_id = 0;
if (info_.hardware_parameters.count("master_id")) {
  master_id = std::stoi(info_.hardware_parameters.at("master_id"));
}
master_ = std::make_unique<ethercat_interface::EcMaster>(master_id);
```

All `master_.method()` call sites are updated to `master_->method()`.

### 2. Release master on destruction

Add `ecrt_release_master(master_)` in `~EcMaster()` to properly release the IgH master on shutdown.

## Why this PR

PR #175 already contains the same core fix, but as part of a broader set of changes.

This PR focuses only on the multi-master issue to keep the patch minimal and easier to review and integrate upstream.

## Impact

* **Single-master setups:** no behavior change
* **Multi-master setups:** fixed, each instance now honors its configured `master_id`
* **Shutdown/restart:** improved cleanup through explicit master release

## ABI note

The change from inline `EcMaster` storage to `std::unique_ptr<EcMaster>` changes class layout. Downstream code using this header should be recompiled.

## Validation

Tested successfully in production on ROS2 Jazzy / Ubuntu 24.04 with:

* **Master 0:** 2× Festo CMMT-AS CiA402 drives
* **Master 1:** FANUC R-30iB with 7 joints + 173 GPIO signals

Both buses initialize and run simultaneously in the same `controller_manager` process.
