### PR TITLE
fix: release EtherCAT master in `EcMaster` destructor

### DIFF
--- a/ethercat_interface/src/ec_master.cpp
+++ b/ethercat_interface/src/ec_master.cpp
@@ -75,6 +75,10 @@ EcMaster::~EcMaster()
       delete domain.second;
     }
   }
+  // Release the EtherCAT master so the kernel module can be reused
+  if (master_) {
+    ecrt_release_master(master_);
+  }
 }
 
 void EcMaster::addSlave(uint16_t alias, uint16_t position, EcSlave * slave)


### PR DESCRIPTION
## Problem

The current `jazzy` branch correctly defers `EcMaster` initialization, so multi-master setups using `master_id` are already supported.

However, `EcMaster` does not explicitly release the IgH master in its destructor. This can leave the master reserved after shutdown and may interfere with clean restart or re-acquisition.

## Solution

Add an explicit `ecrt_release_master(master_)` call in `~EcMaster()`:

```cpp
if (master_ != NULL) {
  ecrt_release_master(master_);
  master_ = NULL;
}
```

This ensures proper cleanup and symmetry with `ecrt_request_master()`.

## Impact

* improves shutdown behavior
* avoids master remaining reserved after process exit
* no impact on runtime behavior

## Why this PR

This PR intentionally focuses on a minimal and isolated fix for proper resource cleanup in the current `jazzy` branch.

## Testing

Validated in a real setup (ROS2 Jazzy / Ubuntu 24.04) with repeated startup / shutdown cycles on a multi-bus EtherCAT configuration.
