### PR TITLE
Allow configurable EtherLab install path and fix compile error

### DIFF
--- a/ethercat_interface/CMakeLists.txt
+++ b/ethercat_interface/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 
 # EtherLab
-set(ETHERLAB_DIR /usr/local/etherlab)
+set(ETHERLAB_DIR "/usr/local/etherlab" CACHE PATH "EtherLab install prefix (contains include/ and lib/)")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 find_library(ETHERCAT_LIB ethercat HINTS ${ETHERLAB_DIR}/lib)

--- a/ethercat_manager/CMakeLists.txt
+++ b/ethercat_manager/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(rclcpp REQUIRED)
 find_package(ethercat_msgs REQUIRED)
 
 # EtherLab
-set(ETHERLAB_DIR /usr/local/etherlab)
+set(ETHERLAB_DIR "/usr/local/etherlab" CACHE PATH "EtherLab install prefix (contains include/ and lib/)")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 find_library(ETHERCAT_LIB ethercat HINTS ${ETHERLAB_DIR}/lib)

--- a/ethercat_manager/include/ethercat_manager/ec_master_async.hpp
+++ b/ethercat_manager/include/ethercat_manager/ec_master_async.hpp
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <ecrt.h>
 #include <errno.h>
+#include <unistd.h>
 #include <sstream>
 #include <map>
 #include <string>


### PR DESCRIPTION
I've found a few issues while compiling in a pixi environment.

Summary

- Make ETHERLAB_DIR a CMake cache variable, allowing users to override it via -DETHERLAB_DIR=... instead of being hardcoded to `/usr/local/etherlab`
- Add missing `#include <unistd.h>` in `ec_master_async.hpp` to fix a compile error