### PR TITLE
Extract core logic to ethercat bus master

### DIFF
--- a/ethercat_driver/include/ethercat_driver/ethercat_bus_manager.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_bus_manager.hpp
@@ -34,8 +34,8 @@ namespace ethercat_driver
 struct ConfiguredEcModule
 {
   std::unordered_map<std::string, std::string> parameters;
-  std::vector<double> * state_interface;
-  std::vector<double> * command_interface;
+  std::vector<double> * input_values;
+  std::vector<double> * output_values;
   std::string component_name;
   std::string module_type;
   size_t module_number;

--- a/ethercat_driver/include/ethercat_driver/ethercat_bus_manager.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_bus_manager.hpp
@@ -41,6 +41,15 @@ struct ConfiguredEcModule
   size_t module_number;
 };
 
+/** Bus-wide EtherCAT settings independent of the ros2_control HardwareInfo representation. */
+struct EthercatBusConfig
+{
+  unsigned int master_id{0};
+  double control_frequency{100.0};
+  std::string transfer_config;
+  std::string fsoe_config;
+};
+
 enum class EthercatCycleResult
 {
   kCompleted,
@@ -53,7 +62,7 @@ class EthercatBusManager
 {
 public:
   bool configureModules(
-    const std::unordered_map<std::string, std::string> & hardware_parameters,
+    const EthercatBusConfig & bus_config,
     const std::vector<ConfiguredEcModule> & modules);
 
   bool activateBus();
@@ -96,7 +105,7 @@ protected:
   bool configNetwork();
 
 protected:
-  std::unordered_map<std::string, std::string> hardware_parameters_;
+  EthercatBusConfig bus_config_;
   std::vector<std::shared_ptr<ethercat_interface::EcSlave>> ec_modules_;
   std::vector<std::unordered_map<std::string, std::string>> ec_module_parameters_;
 

--- a/ethercat_driver/include/ethercat_driver/ethercat_bus_manager.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_bus_manager.hpp
@@ -64,18 +64,6 @@ public:
 
   EthercatCycleResult write();
 
-  uint16_t getAliasOrDefaultAlias(
-    const std::unordered_map<std::string,
-    std::string> & slave_parameters);
-
-  /** @brief Load transfer config YAML file
-   * One use case is to load transfers for FailSafe Over EtherCAT Safety
-   * @param[out] node YAML node containing the transfer configuration root
-   * @param[in] path Path to the YAML file, if empty, the file is loaded from the *fsoe_config*
-   * or *transfer_config* of the YAML document
-   */
-  void loadTransferConfigYamlFile(YAML::Node & node, const std::string & path = "");
-
   /** @brief Get transfer module parameters from YAML file
    * @param[in] config YAML node containing the transfer configuration root
    * @return Vector of maps containing transfer module parameters, each map corresponds to a module
@@ -91,6 +79,18 @@ public:
   std::vector<ethercat_interface::EcTransferNet> getEcTransferNets(const YAML::Node & config);
 
 protected:
+  uint16_t getAliasOrDefaultAlias(
+    const std::unordered_map<std::string,
+    std::string> & slave_parameters);
+
+  /** @brief Load transfer config YAML file
+   * One use case is to load transfers for FailSafe Over EtherCAT Safety
+   * @param[out] node YAML node containing the transfer configuration root
+   * @param[in] path Path to the YAML file, if empty, the file is loaded from the *fsoe_config*
+   * or *transfer_config* of the YAML document
+   */
+  void loadTransferConfigYamlFile(YAML::Node & node, const std::string & path = "");
+
   bool setupMaster();
 
   bool configNetwork();

--- a/ethercat_driver/include/ethercat_driver/ethercat_bus_manager.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_bus_manager.hpp
@@ -1,0 +1,126 @@
+// Copyright 2022 ICUBE Laboratory, University of Strasbourg
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ETHERCAT_DRIVER__ETHERCAT_BUS_MANAGER_HPP_
+#define ETHERCAT_DRIVER__ETHERCAT_BUS_MANAGER_HPP_
+
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <pluginlib/class_loader.hpp>
+
+#include "ethercat_interface/ec_master.hpp"
+#include "ethercat_interface/ec_slave.hpp"
+#include "yaml-cpp/yaml.h"
+
+namespace ethercat_driver
+{
+
+struct ConfiguredEcModule
+{
+  std::unordered_map<std::string, std::string> parameters;
+  std::vector<double> * state_interface;
+  std::vector<double> * command_interface;
+  std::string component_name;
+  std::string module_type;
+  size_t module_number;
+};
+
+enum class EthercatCycleResult
+{
+  kCompleted,
+  kSkippedInactive,
+  kSkippedBusy,
+  kError
+};
+
+class EthercatBusManager
+{
+public:
+  bool configureModules(
+    const std::unordered_map<std::string, std::string> & hardware_parameters,
+    const std::vector<ConfiguredEcModule> & modules);
+
+  bool activateBus();
+
+  void deactivateBus();
+
+  EthercatCycleResult read();
+
+  EthercatCycleResult write();
+
+  uint16_t getAliasOrDefaultAlias(
+    const std::unordered_map<std::string,
+    std::string> & slave_parameters);
+
+  /** @brief Load transfer config YAML file
+   * One use case is to load transfers for FailSafe Over EtherCAT Safety
+   * @param[out] node YAML node containing the transfer configuration root
+   * @param[in] path Path to the YAML file, if empty, the file is loaded from the *fsoe_config*
+   * or *transfer_config* of the YAML document
+   */
+  void loadTransferConfigYamlFile(YAML::Node & node, const std::string & path = "");
+
+  /** @brief Get transfer module parameters from YAML file
+   * @param[in] config YAML node containing the transfer configuration root
+   * @return Vector of maps containing transfer module parameters, each map corresponds to a module
+   * involved in a transfer
+   */
+  std::vector<std::unordered_map<std::string, std::string>> getEcTransferModuleParam(
+    const YAML::Node & config);
+
+  /** @brief Get transfer nets from YAML file
+   * @param[in] config YAML node containing the transfer configuration root
+   * @return Vector of transfer nets
+   */
+  std::vector<ethercat_interface::EcTransferNet> getEcTransferNets(const YAML::Node & config);
+
+protected:
+  bool setupMaster();
+
+  bool configNetwork();
+
+protected:
+  std::unordered_map<std::string, std::string> hardware_parameters_;
+  std::vector<std::shared_ptr<ethercat_interface::EcSlave>> ec_modules_;
+  std::vector<std::unordered_map<std::string, std::string>> ec_module_parameters_;
+
+  pluginlib::ClassLoader<ethercat_interface::EcSlave> ec_loader_{
+    "ethercat_interface", "ethercat_interface::EcSlave"};
+
+  double control_frequency_;
+
+  std::shared_ptr<ethercat_interface::EcMaster> master_;
+  std::mutex ec_mutex_;
+  bool activated_{false};
+
+  /** Transfer nets */
+  std::vector<ethercat_interface::EcTransferNet> ec_transfer_nets_;
+
+  /** Indexes of modules inside ec_modules_ vector that are transfer masters */
+  std::vector<size_t> ec_transfer_masters_;
+  /** Indexes of modules inside ec_modules_ vector that are transfer slaves only */
+  std::vector<size_t> ec_transfer_slaves_;
+
+  /** Empty interfaces */
+  std::vector<double> empty_interface_;
+};
+
+}  // namespace ethercat_driver
+
+#endif  // ETHERCAT_DRIVER__ETHERCAT_BUS_MANAGER_HPP_

--- a/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
@@ -19,7 +19,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <pluginlib/class_loader.hpp>
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/system_interface.hpp"
@@ -27,10 +26,8 @@
 #include "rclcpp/macros.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
+#include "ethercat_driver/ethercat_bus_manager.hpp"
 #include "ethercat_driver/visibility_control.h"
-#include "ethercat_interface/ec_slave.hpp"
-#include "ethercat_interface/ec_master.hpp"
-#include "yaml-cpp/yaml.h"
 
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
@@ -68,49 +65,6 @@ public:
   hardware_interface::return_type write(const rclcpp::Time &, const rclcpp::Duration &) override;
 
 protected:
-  std::vector<std::unordered_map<std::string, std::string>> getEcModuleParam(
-    const std::string & urdf,
-    const std::string & component_name,
-    const std::string & component_type);
-
-  uint16_t getAliasOrDefaultAlias(
-    const std::unordered_map<std::string,
-    std::string> & slave_parameters);
-
-  virtual CallbackReturn setupMaster();
-
-  CallbackReturn configNetwork();
-
-  /** @brief Load transfer config YAML file
-   * One use case is to load transfers for FailSafe Over EtherCAT Safety
-   * @param[out] node YAML node containing the transfer configuration root
-   * @param[in] path Path to the YAML file, if empty, the file is loaded from the *fsoe_config*
-   * or *transfer_config* of the YAML document
-   */
-  void loadTransferConfigYamlFile(YAML::Node & node, const std::string & path = "");
-
-  /** @brief Get transfer module parameters from YAML file
-   * @param[in] config YAML node containing the transfer configuration root
-   * @return Vector of maps containing transfer module parameters, each map corresponds to a module
-   * involved in a transfer
-   */
-  std::vector<std::unordered_map<std::string, std::string>> getEcTransferModuleParam(
-    const YAML::Node & config);
-
-  /** @brief Get transfer nets from YAML file
-   * @param[in] config YAML node containing the transfer configuration root
-   * @return Vector of transfer nets
-   */
-  std::vector<ethercat_interface::EcTransferNet> getEcTransferNets(const YAML::Node & config);
-
-  /** @brief Configure the transfer networks
-   */
-  void configTransferNetwork();
-
-protected:
-  std::vector<std::shared_ptr<ethercat_interface::EcSlave>> ec_modules_;
-  std::vector<std::unordered_map<std::string, std::string>> ec_module_parameters_;
-
   std::vector<std::vector<double>> hw_joint_commands_;
   std::vector<std::vector<double>> hw_sensor_commands_;
   std::vector<std::vector<double>> hw_gpio_commands_;
@@ -118,25 +72,7 @@ protected:
   std::vector<std::vector<double>> hw_sensor_states_;
   std::vector<std::vector<double>> hw_gpio_states_;
 
-  pluginlib::ClassLoader<ethercat_interface::EcSlave> ec_loader_{
-    "ethercat_interface", "ethercat_interface::EcSlave"};
-
-  double control_frequency_;
-
-  std::shared_ptr<ethercat_interface::EcMaster> master_;
-  std::mutex ec_mutex_;
-  bool activated_;
-
-  /** Transfer nets */
-  std::vector<ethercat_interface::EcTransferNet> ec_transfer_nets_;
-
-  /** Indexes of modules inside ec_modules_ vector that are transfer masters */
-  std::vector<size_t> ec_transfer_masters_;
-  /** Indexes of modules inside ec_modules_ vector that are transfer slaves only */
-  std::vector<size_t> ec_transfer_slaves_;
-
-  /** Empty interfaces */
-  std::vector<double> empty_interface_;
+  EthercatBusManager bus_manager_;
 };
 }  // namespace ethercat_driver
 

--- a/ethercat_driver/include/ethercat_driver/ethercat_ros2_control_xml_parser.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_ros2_control_xml_parser.hpp
@@ -22,14 +22,16 @@
 namespace ethercat_driver
 {
 
-class EthercatRos2ControlXmlParser
-{
-public:
-  static std::vector<std::unordered_map<std::string, std::string>> getEcModuleParam(
-    const std::string & urdf,
-    const std::string & component_name,
-    const std::string & component_type);
-};
+/** @brief Parse <ec_module> blocks for a given ros2_control component from a URDF/Xacro string.
+ * @param[in] urdf Full URDF/Xacro XML string (typically info_.original_xml).
+ * @param[in] component_name Name attribute of the joint, gpio or sensor element to look under.
+ * @param[in] component_type Element tag to look for: "joint", "gpio", or "sensor".
+ * @return One parameter map per <ec_module> child of the matching component.
+ */
+std::vector<std::unordered_map<std::string, std::string>> getEcModuleParam(
+  const std::string & urdf,
+  const std::string & component_name,
+  const std::string & component_type);
 
 }  // namespace ethercat_driver
 

--- a/ethercat_driver/include/ethercat_driver/ethercat_ros2_control_xml_parser.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_ros2_control_xml_parser.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 ICUBE Laboratory, University of Strasbourg
+// Copyright 2022 ICUBE Laboratory, University of Strasbourg
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,24 +11,26 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// Author: Manuel YGUEL (yguel.robotics@gmail.com)
 
-#ifndef TESTHELPER_ETHERCAT_SAFETY_DRIVER_HPP_
-#define TESTHELPER_ETHERCAT_SAFETY_DRIVER_HPP_
+#ifndef ETHERCAT_DRIVER__ETHERCAT_ROS2_CONTROL_XML_PARSER_HPP_
+#define ETHERCAT_DRIVER__ETHERCAT_ROS2_CONTROL_XML_PARSER_HPP_
 
-#include "ethercat_driver/ethercat_driver.hpp"
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace ethercat_driver
 {
 
-class TestHelperEthercatSafetyDriver : public ethercat_driver::EthercatDriver
+class EthercatRos2ControlXmlParser
 {
 public:
-  using EthercatDriver::getEcTransferModuleParam;
-  using EthercatDriver::getEcTransferNets;
+  static std::vector<std::unordered_map<std::string, std::string>> getEcModuleParam(
+    const std::string & urdf,
+    const std::string & component_name,
+    const std::string & component_type);
 };
 
 }  // namespace ethercat_driver
 
-#endif  // TESTHELPER_ETHERCAT_SAFETY_DRIVER_HPP_
+#endif  // ETHERCAT_DRIVER__ETHERCAT_ROS2_CONTROL_XML_PARSER_HPP_

--- a/ethercat_driver/src/ethercat_bus_manager.cpp
+++ b/ethercat_driver/src/ethercat_bus_manager.cpp
@@ -94,7 +94,16 @@ bool EthercatBusManager::configureModules(
   const std::vector<ConfiguredEcModule> & modules)
 {
   const std::lock_guard<std::mutex> lock(ec_mutex_);
-  activated_ = false;
+  // configureModules must be called only when the bus is not active.
+  // ros2_control's lifecycle guarantees this for on_init(); reject otherwise
+  // because clearing internal state below would orphan an active master_
+  // without going through stop().
+  if (activated_) {
+    RCLCPP_FATAL(
+      rclcpp::get_logger("EthercatBusManager"),
+      "configureModules() called while bus is active; deactivate first.");
+    return false;
+  }
   hardware_parameters_ = hardware_parameters;
   ec_modules_.clear();
   ec_module_parameters_.clear();
@@ -103,8 +112,14 @@ bool EthercatBusManager::configureModules(
   ec_transfer_slaves_.clear();
   master_.reset();
 
+  // Collect all module parameters up front so the load loop mirrors the
+  // original on_init() body structure (plugin load + setupSlave + push to ec_modules_).
+  ec_module_parameters_.reserve(modules.size());
   for (const auto & configured_module : modules) {
     ec_module_parameters_.push_back(configured_module.parameters);
+  }
+
+  for (const auto & configured_module : modules) {
     try {
       auto module = ec_loader_.createSharedInstance(configured_module.parameters.at("plugin"));
       if (!module->setupSlave(
@@ -466,7 +481,7 @@ void EthercatBusManager::loadTransferConfigYamlFile(YAML::Node & node, const std
   } catch (const YAML::ParserException & ex) {
     std::string msg =
       std::string(
-      "EthercatDriver : failed to load transfer configuration "
+      "EthercatBusManager : failed to load transfer configuration "
       "(YAML file is incorrect): ") + std::string(ex.what());
     RCLCPP_FATAL(
       rclcpp::get_logger("EthercatBusManager"), msg.c_str() );
@@ -474,7 +489,7 @@ void EthercatBusManager::loadTransferConfigYamlFile(YAML::Node & node, const std
   } catch (const YAML::BadFile & ex) {
     std::string msg =
       std::string(
-      "EthercatDriver : failed to load transfer configuration "
+      "EthercatBusManager : failed to load transfer configuration "
       "(file path is incorrect or file is damaged): " + std::string(ex.what()));
     RCLCPP_FATAL(
       rclcpp::get_logger("EthercatBusManager"), msg.c_str() );
@@ -482,7 +497,7 @@ void EthercatBusManager::loadTransferConfigYamlFile(YAML::Node & node, const std
   } catch (std::exception & e) {
     std::string msg =
       std::string(
-      "EthercatDriver : error while loading transfer configuration: ") + std::string(e.what());
+      "EthercatBusManager : error while loading transfer configuration: ") + std::string(e.what());
     RCLCPP_FATAL(
       rclcpp::get_logger("EthercatBusManager"), msg.c_str() );
     throw std::runtime_error(msg);

--- a/ethercat_driver/src/ethercat_bus_manager.cpp
+++ b/ethercat_driver/src/ethercat_bus_manager.cpp
@@ -90,7 +90,7 @@ uint16_t EthercatBusManager::getAliasOrDefaultAlias(
 }
 
 bool EthercatBusManager::configureModules(
-  const std::unordered_map<std::string, std::string> & hardware_parameters,
+  const EthercatBusConfig & bus_config,
   const std::vector<ConfiguredEcModule> & modules)
 {
   const std::lock_guard<std::mutex> lock(ec_mutex_);
@@ -104,7 +104,7 @@ bool EthercatBusManager::configureModules(
       "configureModules() called while bus is active; deactivate first.");
     return false;
   }
-  hardware_parameters_ = hardware_parameters;
+  bus_config_ = bus_config;
   ec_modules_.clear();
   ec_module_parameters_.clear();
   ec_transfer_nets_.clear();
@@ -149,8 +149,7 @@ bool EthercatBusManager::configureModules(
   RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Got %li modules", ec_modules_.size());
 
   // Check if a transfer configuration is provided
-  if (hardware_parameters_.find("fsoe_config") != hardware_parameters_.end() ||
-    hardware_parameters_.find("transfer_config") != hardware_parameters_.end())
+  if (!bus_config_.fsoe_config.empty() || !bus_config_.transfer_config.empty())
   {
     RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Transfer configuration detected, ...");
 
@@ -264,43 +263,16 @@ bool EthercatBusManager::configureModules(
 
 bool EthercatBusManager::setupMaster()
 {
-  unsigned int master_id = 666;
-  // Get master id
-  if (hardware_parameters_.find("master_id") == hardware_parameters_.end()) {
-    // Master id was not provided, default to 0
-    master_id = 0;
-  } else {
-    try {
-      master_id = std::stoul(hardware_parameters_["master_id"]);
-    } catch (std::exception & e) {
-      RCLCPP_FATAL(
-        rclcpp::get_logger("EthercatBusManager"), "Invalid master id (%s)!", e.what());
-      return false;
-    }
-  }
-  master_ = std::make_shared<ethercat_interface::EcMaster>(master_id);
+  master_ = std::make_shared<ethercat_interface::EcMaster>(bus_config_.master_id);
 
   return true;
 }
 
 bool EthercatBusManager::configNetwork()
 {
-  // Get control frequency
-  if (hardware_parameters_.find("control_frequency") == hardware_parameters_.end()) {
-    // Control frequency was not provided, default to 100 Hz
-    control_frequency_ = 100.0;
-  } else {
-    try {
-      control_frequency_ = std::stod(hardware_parameters_["control_frequency"]);
-    } catch (std::exception & e) {
-      RCLCPP_FATAL(
-        rclcpp::get_logger("EthercatBusManager"), "Invalid control frequency (%s)!", e.what());
-      return false;
-    }
-  }
-
   // start EC and wait until state operative
 
+  control_frequency_ = bus_config_.control_frequency;
   master_->setCtrlFrequency(control_frequency_);
 
   for (auto i = 0ul; i < ec_modules_.size(); i++) {
@@ -442,9 +414,8 @@ void EthercatBusManager::loadTransferConfigYamlFile(YAML::Node & node, const std
 {
   std::string file_path;
   if (path.empty()) {
-    // Get the fsoe_config or transfer_config parameter of the ethercat_driver hardware plugin
-    if (hardware_parameters_.find("fsoe_config") == hardware_parameters_.end() &&
-      hardware_parameters_.find("transfer_config") == hardware_parameters_.end() )
+    // Get the fsoe_config or transfer_config path from the bus configuration
+    if (bus_config_.fsoe_config.empty() && bus_config_.transfer_config.empty())
     {
       std::string msg("transfer_config or fsoe_config parameter is missing!");
       // Transfer (or fsoe) config file was not provided
@@ -452,8 +423,7 @@ void EthercatBusManager::loadTransferConfigYamlFile(YAML::Node & node, const std
         rclcpp::get_logger("EthercatBusManager"), msg.c_str());
       throw std::runtime_error(msg);
     }
-    if (hardware_parameters_.find("fsoe_config") != hardware_parameters_.end() &&
-      hardware_parameters_.find("transfer_config") != hardware_parameters_.end())
+    if (!bus_config_.fsoe_config.empty() && !bus_config_.transfer_config.empty())
     {
       std::string msg(
         "Both transfer_config and fsoe_config parameters are provided! Please provide only one "
@@ -462,15 +432,15 @@ void EthercatBusManager::loadTransferConfigYamlFile(YAML::Node & node, const std
         rclcpp::get_logger("EthercatBusManager"), msg.c_str());
       throw std::runtime_error(msg);
     }
-    if (hardware_parameters_.find("fsoe_config") != hardware_parameters_.end() ) {
+    if (!bus_config_.fsoe_config.empty()) {
       std::string msg("The fsoe_config parameter is deprecated. "
         "Please use transfer_config instead.");
       RCLCPP_WARN(
         rclcpp::get_logger("EthercatBusManager"), msg.c_str());
-      file_path = hardware_parameters_.at("fsoe_config");
+      file_path = bus_config_.fsoe_config;
     }
-    if (hardware_parameters_.find("transfer_config") != hardware_parameters_.end()) {
-      file_path = hardware_parameters_.at("transfer_config");
+    if (!bus_config_.transfer_config.empty()) {
+      file_path = bus_config_.transfer_config;
     }
   } else {
     file_path = path;

--- a/ethercat_driver/src/ethercat_bus_manager.cpp
+++ b/ethercat_driver/src/ethercat_bus_manager.cpp
@@ -124,8 +124,8 @@ bool EthercatBusManager::configureModules(
       auto module = ec_loader_.createSharedInstance(configured_module.parameters.at("plugin"));
       if (!module->setupSlave(
           configured_module.parameters,
-          configured_module.state_interface,
-          configured_module.command_interface))
+          configured_module.input_values,
+          configured_module.output_values))
       {
         RCLCPP_FATAL(
           rclcpp::get_logger("EthercatBusManager"),

--- a/ethercat_driver/src/ethercat_bus_manager.cpp
+++ b/ethercat_driver/src/ethercat_bus_manager.cpp
@@ -129,9 +129,9 @@ bool EthercatBusManager::configureModules(
       {
         RCLCPP_FATAL(
           rclcpp::get_logger("EthercatBusManager"),
-          "Setup of %s module %li FAILED.",
+          "Setup of %s module %zu FAILED.",
           configured_module.module_type.c_str(),
-          static_cast<unsigned long>(configured_module.module_number));
+          configured_module.module_number);
         return false;
       }
       module->setAliasAndPosition(
@@ -149,8 +149,7 @@ bool EthercatBusManager::configureModules(
   RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Got %li modules", ec_modules_.size());
 
   // Check if a transfer configuration is provided
-  if (!bus_config_.fsoe_config.empty() || !bus_config_.transfer_config.empty())
-  {
+  if (!bus_config_.fsoe_config.empty() || !bus_config_.transfer_config.empty()) {
     RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Transfer configuration detected, ...");
 
     YAML::Node config;
@@ -415,16 +414,14 @@ void EthercatBusManager::loadTransferConfigYamlFile(YAML::Node & node, const std
   std::string file_path;
   if (path.empty()) {
     // Get the fsoe_config or transfer_config path from the bus configuration
-    if (bus_config_.fsoe_config.empty() && bus_config_.transfer_config.empty())
-    {
+    if (bus_config_.fsoe_config.empty() && bus_config_.transfer_config.empty()) {
       std::string msg("transfer_config or fsoe_config parameter is missing!");
       // Transfer (or fsoe) config file was not provided
       RCLCPP_FATAL(
         rclcpp::get_logger("EthercatBusManager"), msg.c_str());
       throw std::runtime_error(msg);
     }
-    if (!bus_config_.fsoe_config.empty() && !bus_config_.transfer_config.empty())
-    {
+    if (!bus_config_.fsoe_config.empty() && !bus_config_.transfer_config.empty()) {
       std::string msg(
         "Both transfer_config and fsoe_config parameters are provided! Please provide only one "
         "of them.");
@@ -474,7 +471,8 @@ void EthercatBusManager::loadTransferConfigYamlFile(YAML::Node & node, const std
   }
 }
 
-std::vector<std::unordered_map<std::string, std::string>> EthercatBusManager::getEcTransferModuleParam(
+std::vector<std::unordered_map<std::string,
+  std::string>> EthercatBusManager::getEcTransferModuleParam(
   const YAML::Node & config)
 {
   if (0 == config.size() ) {

--- a/ethercat_driver/src/ethercat_bus_manager.cpp
+++ b/ethercat_driver/src/ethercat_bus_manager.cpp
@@ -1,0 +1,600 @@
+// Copyright 2022 ICUBE Laboratory, University of Strasbourg
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ethercat_driver/ethercat_bus_manager.hpp"
+
+#include <algorithm>
+#include <ctime>
+#include <regex>
+#include <stdexcept>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace ethercat_driver
+{
+
+unsigned int uint_from_string(const std::string & str)
+{
+  // Strip leading and trailing whitespaces
+  std::string s = std::regex_replace(str, std::regex("^ +| +$|( ) +"), "$1");
+  // Test if the number is in hexadecimal format
+  if (s.find("0x") == 0) {
+    return std::stoul(s, nullptr, 16);
+  }
+  return std::stoul(s);
+}
+
+void getTransferMemoryInfo(
+  const YAML::Node & element,
+  ethercat_interface::EcMemoryEntry & entry,
+  const std::string & dir,
+  const std::string & transfer_net_name)
+{
+  if (!element["ec_module"]) {
+    std::string msg = "Transfer definition without ec_module entry, net: " +
+      transfer_net_name + " direction: " + dir;
+    throw std::runtime_error(msg);
+  }
+  if (!element["index"]) {
+    std::string msg = "Transfer definition without index entry, net: " +
+      transfer_net_name + " direction: " + dir;
+    throw std::runtime_error(msg);
+  }
+  if (!element["subindex"]) {
+    std::string msg = "Transfer definition without subindex entry, net: " +
+      transfer_net_name + " direction: " + dir;
+    throw std::runtime_error(msg);
+  }
+
+  entry.module_name = element["ec_module"].as<std::string>();
+  entry.index = uint_from_string(element["index"].as<std::string>());
+  entry.subindex = uint_from_string(element["subindex"].as<std::string>());
+}
+
+void throwErrorIfModuleParametersNotFound(
+  const ethercat_interface::EcTransferEntry & transfer,
+  const std::string & module_name,
+  const std::string & transfer_net_name,
+  const std::string & direction)
+{
+  std::string msg = "In transfer net: " + transfer_net_name + ", for transfer " +
+    transfer.to_simple_string() + ", the module name of the " + direction + "( " + module_name +
+    ") among all the recorded modules.";
+  RCLCPP_ERROR(
+    rclcpp::get_logger(
+      "EthercatBusManager"), msg.c_str());
+  throw std::runtime_error(msg);
+}
+
+uint16_t EthercatBusManager::getAliasOrDefaultAlias(
+  const std::unordered_map<std::string,
+  std::string> & slave_parameters)
+{
+  if (slave_parameters.find("alias") != slave_parameters.end()) {
+    return std::stoul(slave_parameters.at("alias"));
+  } else {
+    return 0;
+  }
+}
+
+bool EthercatBusManager::configureModules(
+  const std::unordered_map<std::string, std::string> & hardware_parameters,
+  const std::vector<ConfiguredEcModule> & modules)
+{
+  const std::lock_guard<std::mutex> lock(ec_mutex_);
+  activated_ = false;
+  hardware_parameters_ = hardware_parameters;
+  ec_modules_.clear();
+  ec_module_parameters_.clear();
+  ec_transfer_nets_.clear();
+  ec_transfer_masters_.clear();
+  ec_transfer_slaves_.clear();
+  master_.reset();
+
+  for (const auto & configured_module : modules) {
+    ec_module_parameters_.push_back(configured_module.parameters);
+    try {
+      auto module = ec_loader_.createSharedInstance(configured_module.parameters.at("plugin"));
+      if (!module->setupSlave(
+          configured_module.parameters,
+          configured_module.state_interface,
+          configured_module.command_interface))
+      {
+        RCLCPP_FATAL(
+          rclcpp::get_logger("EthercatBusManager"),
+          "Setup of %s module %li FAILED.",
+          configured_module.module_type.c_str(),
+          static_cast<unsigned long>(configured_module.module_number));
+        return false;
+      }
+      module->setAliasAndPosition(
+        getAliasOrDefaultAlias(configured_module.parameters),
+        std::stoul(configured_module.parameters.at("position")));
+      ec_modules_.push_back(module);
+    } catch (pluginlib::PluginlibException & ex) {
+      RCLCPP_FATAL(
+        rclcpp::get_logger("EthercatBusManager"),
+        "The plugin of %s failed to load for some reason. Error: %s\n",
+        configured_module.component_name.c_str(), ex.what());
+    }
+  }
+
+  RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Got %li modules", ec_modules_.size());
+
+  // Check if a transfer configuration is provided
+  if (hardware_parameters_.find("fsoe_config") != hardware_parameters_.end() ||
+    hardware_parameters_.find("transfer_config") != hardware_parameters_.end())
+  {
+    RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Transfer configuration detected, ...");
+
+    YAML::Node config;
+    // Load the transfer config file
+    loadTransferConfigYamlFile(config);
+
+    // Parse transfer modules from the transfer yaml file
+    auto transfer_module_params = getEcTransferModuleParam(config);
+
+    // Append the transfer modules parameters to the list of modules parameters
+    size_t idx_1st = ec_module_parameters_.size();
+    ec_module_parameters_.insert(
+      ec_module_parameters_.end(), transfer_module_params.begin(), transfer_module_params.end());
+    for (size_t i = 0; i < transfer_module_params.size(); i++) {
+      ec_transfer_slaves_.push_back(idx_1st + i);
+    }
+
+    // Parse transfer nets from the transfer yaml file
+    ec_transfer_nets_ = getEcTransferNets(config);
+
+    // Append the transfer modules to the list of modules and load them
+    for (const auto & transfer_module_param : transfer_module_params) {
+      try {
+        auto ec_module = ec_loader_.createSharedInstance(transfer_module_param.at("plugin"));
+        if (!ec_module->setupSlave(
+            transfer_module_param, &empty_interface_, &empty_interface_))
+        {
+          const std::string & module_name = transfer_module_param.at("name");
+          RCLCPP_FATAL(
+            rclcpp::get_logger("EthercatBusManager"),
+            "Setup of transfer only module %s FAILED.", module_name.c_str() );
+          return false;
+        }
+
+        auto idx = ec_modules_.size();
+        ec_module->setAliasAndPosition(
+          getAliasOrDefaultAlias(transfer_module_param),
+          std::stoul(transfer_module_param.at("position")));
+        ec_modules_.push_back(ec_module);
+        ec_transfer_slaves_.push_back(idx);
+      } catch (const pluginlib::PluginlibException & ex) {
+        const std::string & module_name = transfer_module_param.at("name");
+        RCLCPP_ERROR(
+          rclcpp::get_logger(
+            "EthercatBusManager"),
+          "The plugin failed to load for transfer module %s. Error: %s\n",
+          module_name.c_str(), ex.what());
+      }
+    }
+
+    // Find all masters from the nets
+    {
+      std::vector<std::string> master_names;
+      for (const auto & net : ec_transfer_nets_) {
+        master_names.push_back(net.master);
+      }
+      for (size_t i = 0; i < ec_module_parameters_.size(); i++) {
+        if (std::find(
+            master_names.begin(), master_names.end(),
+            ec_module_parameters_[i].at("name")) !=
+          master_names.end())
+        {
+          ec_transfer_masters_.push_back(i);
+        }
+      }
+    }
+
+    // Identify (alias,position) all the modules participating in transfers
+    for (auto & net : ec_transfer_nets_) {
+      for (auto & transfer : net.transfers) {
+        // Update each EcMemoryEntry with the alias and position of the module
+        size_t in_idx = ec_module_parameters_.size();
+        for (in_idx = 0; in_idx < ec_module_parameters_.size(); ++in_idx) {
+          if (ec_module_parameters_[in_idx].at("name") == transfer.input.module_name) {
+            break;
+          }
+        }
+        size_t out_idx = ec_module_parameters_.size();
+        for (out_idx = 0; out_idx < ec_module_parameters_.size(); ++out_idx) {
+          if (ec_module_parameters_[out_idx].at("name") == transfer.output.module_name) {
+            break;
+          }
+        }
+        if (in_idx == ec_module_parameters_.size()) {
+          throwErrorIfModuleParametersNotFound(
+            transfer, transfer.input.module_name, net.name, "input");
+        }
+        if (out_idx == ec_module_parameters_.size()) {
+          throwErrorIfModuleParametersNotFound(
+            transfer, transfer.output.module_name, net.name, "output");
+        }
+
+        const auto & input_module = ec_modules_[in_idx];
+        const auto & output_module = ec_modules_[out_idx];
+
+        transfer.input.alias = input_module->alias_;
+        transfer.input.position = input_module->position_;
+        transfer.output.alias = output_module->alias_;
+        transfer.output.position = output_module->position_;
+      }
+    }
+
+    RCLCPP_INFO(
+      rclcpp::get_logger("EthercatBusManager"),
+      "Transfer configuration loaded successfully!");
+  }
+
+  return true;
+}
+
+bool EthercatBusManager::setupMaster()
+{
+  unsigned int master_id = 666;
+  // Get master id
+  if (hardware_parameters_.find("master_id") == hardware_parameters_.end()) {
+    // Master id was not provided, default to 0
+    master_id = 0;
+  } else {
+    try {
+      master_id = std::stoul(hardware_parameters_["master_id"]);
+    } catch (std::exception & e) {
+      RCLCPP_FATAL(
+        rclcpp::get_logger("EthercatBusManager"), "Invalid master id (%s)!", e.what());
+      return false;
+    }
+  }
+  master_ = std::make_shared<ethercat_interface::EcMaster>(master_id);
+
+  return true;
+}
+
+bool EthercatBusManager::configNetwork()
+{
+  // Get control frequency
+  if (hardware_parameters_.find("control_frequency") == hardware_parameters_.end()) {
+    // Control frequency was not provided, default to 100 Hz
+    control_frequency_ = 100.0;
+  } else {
+    try {
+      control_frequency_ = std::stod(hardware_parameters_["control_frequency"]);
+    } catch (std::exception & e) {
+      RCLCPP_FATAL(
+        rclcpp::get_logger("EthercatBusManager"), "Invalid control frequency (%s)!", e.what());
+      return false;
+    }
+  }
+
+  // start EC and wait until state operative
+
+  master_->setCtrlFrequency(control_frequency_);
+
+  for (auto i = 0ul; i < ec_modules_.size(); i++) {
+    master_->addSlave(ec_modules_[i].get());
+  }
+
+  // configure SDO
+  for (auto i = 0ul; i < ec_modules_.size(); i++) {
+    for (auto & sdo : ec_modules_[i]->sdo_config) {
+      uint32_t abort_code;
+      int ret = master_->configSlaveSdo(
+        std::stod(ec_module_parameters_[i]["position"]),
+        sdo,
+        &abort_code);
+      if (ret) {
+        RCLCPP_INFO(
+          rclcpp::get_logger("EthercatBusManager"),
+          "Failed to download config SDO for module at position %s with Error: %d",
+          ec_module_parameters_[i]["position"].c_str(),
+          abort_code);
+      }
+    }
+  }
+
+  return true;
+}
+
+bool EthercatBusManager::activateBus()
+{
+  const std::lock_guard<std::mutex> lock(ec_mutex_);
+  if (activated_) {
+    RCLCPP_FATAL(rclcpp::get_logger("EthercatBusManager"), "Double on_activate()");
+    return false;
+  }
+  RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Starting ...please wait...");
+
+  // setup master
+  if (!setupMaster()) {
+    return false;
+  }
+  // configure network
+  if (!configNetwork()) {
+    return false;
+  }
+
+  if (!master_->activate()) {
+    RCLCPP_ERROR(rclcpp::get_logger("EthercatBusManager"), "Activate EcMaster failed");
+    return false;
+  }
+  RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Activated EcMaster!");
+
+  // Configure transfer network if transfer nets are defined
+  if (!ec_transfer_nets_.empty()) {
+    RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Configuring transfer network...");
+    master_->registerTransferInDomain(ec_transfer_nets_);
+    RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Transfer network configured!");
+  }
+
+  // start after one second
+  struct timespec t;
+  clock_gettime(CLOCK_MONOTONIC, &t);
+  t.tv_sec++;
+
+  bool running = true;
+  while (running) {
+    // wait until next shot
+    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &t, NULL);
+    // update EtherCAT bus
+
+    master_->update();
+
+    // check if operational
+    bool isAllInit = true;
+    for (auto & module : ec_modules_) {
+      isAllInit = isAllInit && module->initialized();
+    }
+    if (isAllInit) {
+      running = false;
+    }
+    // calculate next shot. carry over nanoseconds into microseconds.
+    t.tv_nsec += master_->getInterval();
+    while (t.tv_nsec >= 1000000000) {
+      t.tv_nsec -= 1000000000;
+      t.tv_sec++;
+    }
+  }
+
+  RCLCPP_INFO(
+    rclcpp::get_logger("EthercatBusManager"), "System Successfully started!");
+
+  activated_ = true;
+
+  return true;
+}
+
+void EthercatBusManager::deactivateBus()
+{
+  const std::lock_guard<std::mutex> lock(ec_mutex_);
+  activated_ = false;
+
+  RCLCPP_INFO(rclcpp::get_logger("EthercatBusManager"), "Stopping ...please wait...");
+
+  // stop EC and disconnect
+  master_->stop();
+
+  RCLCPP_INFO(
+    rclcpp::get_logger("EthercatBusManager"), "System successfully stopped!");
+}
+
+EthercatCycleResult EthercatBusManager::read()
+{
+  // try to lock so we can avoid blocking the read/write loop on the lock.
+  const std::unique_lock<std::mutex> lock(ec_mutex_, std::try_to_lock);
+  if (!lock.owns_lock()) {
+    return EthercatCycleResult::kSkippedBusy;
+  }
+  if (activated_) {
+    master_->readData();
+    return EthercatCycleResult::kCompleted;
+  }
+  return EthercatCycleResult::kSkippedInactive;
+}
+
+EthercatCycleResult EthercatBusManager::write()
+{
+  // try to lock so we can avoid blocking the read/write loop on the lock.
+  const std::unique_lock<std::mutex> lock(ec_mutex_, std::try_to_lock);
+  if (!lock.owns_lock()) {
+    return EthercatCycleResult::kSkippedBusy;
+  }
+  if (activated_) {
+    master_->writeData();
+    return EthercatCycleResult::kCompleted;
+  }
+  return EthercatCycleResult::kSkippedInactive;
+}
+
+void EthercatBusManager::loadTransferConfigYamlFile(YAML::Node & node, const std::string & path)
+{
+  std::string file_path;
+  if (path.empty()) {
+    // Get the fsoe_config or transfer_config parameter of the ethercat_driver hardware plugin
+    if (hardware_parameters_.find("fsoe_config") == hardware_parameters_.end() &&
+      hardware_parameters_.find("transfer_config") == hardware_parameters_.end() )
+    {
+      std::string msg("transfer_config or fsoe_config parameter is missing!");
+      // Transfer (or fsoe) config file was not provided
+      RCLCPP_FATAL(
+        rclcpp::get_logger("EthercatBusManager"), msg.c_str());
+      throw std::runtime_error(msg);
+    }
+    if (hardware_parameters_.find("fsoe_config") != hardware_parameters_.end() &&
+      hardware_parameters_.find("transfer_config") != hardware_parameters_.end())
+    {
+      std::string msg(
+        "Both transfer_config and fsoe_config parameters are provided! Please provide only one "
+        "of them.");
+      RCLCPP_FATAL(
+        rclcpp::get_logger("EthercatBusManager"), msg.c_str());
+      throw std::runtime_error(msg);
+    }
+    if (hardware_parameters_.find("fsoe_config") != hardware_parameters_.end() ) {
+      std::string msg("The fsoe_config parameter is deprecated. "
+        "Please use transfer_config instead.");
+      RCLCPP_WARN(
+        rclcpp::get_logger("EthercatBusManager"), msg.c_str());
+      file_path = hardware_parameters_.at("fsoe_config");
+    }
+    if (hardware_parameters_.find("transfer_config") != hardware_parameters_.end()) {
+      file_path = hardware_parameters_.at("transfer_config");
+    }
+  } else {
+    file_path = path;
+  }
+
+  try {
+    node = YAML::LoadFile(file_path);
+  } catch (const YAML::ParserException & ex) {
+    std::string msg =
+      std::string(
+      "EthercatDriver : failed to load transfer configuration "
+      "(YAML file is incorrect): ") + std::string(ex.what());
+    RCLCPP_FATAL(
+      rclcpp::get_logger("EthercatBusManager"), msg.c_str() );
+    throw std::runtime_error(msg);
+  } catch (const YAML::BadFile & ex) {
+    std::string msg =
+      std::string(
+      "EthercatDriver : failed to load transfer configuration "
+      "(file path is incorrect or file is damaged): " + std::string(ex.what()));
+    RCLCPP_FATAL(
+      rclcpp::get_logger("EthercatBusManager"), msg.c_str() );
+    throw std::runtime_error(msg);
+  } catch (std::exception & e) {
+    std::string msg =
+      std::string(
+      "EthercatDriver : error while loading transfer configuration: ") + std::string(e.what());
+    RCLCPP_FATAL(
+      rclcpp::get_logger("EthercatBusManager"), msg.c_str() );
+    throw std::runtime_error(msg);
+  }
+}
+
+std::vector<std::unordered_map<std::string, std::string>> EthercatBusManager::getEcTransferModuleParam(
+  const YAML::Node & config)
+{
+  if (0 == config.size() ) {
+    std::string msg = "Empty transfer_config or fsoe_config parameter!";
+    RCLCPP_FATAL(
+      rclcpp::get_logger("EthercatBusManager"), msg.c_str());
+    throw std::runtime_error(msg);
+  }
+  std::vector<std::unordered_map<std::string, std::string>> module_params;
+  std::unordered_map<std::string, std::string> module_param;
+
+  // It is possible that modules are only involved in transfers and hence
+  // not declared in the ros2_control xacro file.
+  // This is a common situation with modules only involved in safety
+  // operations. In this case, it is necessary to find the plugin to load,
+  // the position and the alias for those slaves.
+  if (config["transfer_modules"]) {
+    for (const auto & module : config["transfer_modules"]) {
+      module_param.clear();
+      module_param["name"] = module["name"].as<std::string>();
+      module_param["plugin"] = module["plugin"].as<std::string>();
+      for (const auto & param : module["parameters"]) {
+        module_param[param.first.as<std::string>()] = param.second.as<std::string>();
+      }
+      module_params.push_back(module_param);
+    }
+  }
+
+  if (config["safety_modules"]) {
+    for (const auto & module : config["safety_modules"]) {
+      module_param.clear();
+      module_param["name"] = module["name"].as<std::string>();
+      module_param["plugin"] = module["plugin"].as<std::string>();
+      for (const auto & param : module["parameters"]) {
+        module_param[param.first.as<std::string>()] = param.second.as<std::string>();
+      }
+      module_params.push_back(module_param);
+    }
+  }
+
+  return module_params;
+}
+
+std::vector<ethercat_interface::EcTransferNet> EthercatBusManager::getEcTransferNets(
+  const YAML::Node & config)
+{
+  if (0 == config.size() ) {
+    std::string msg = "Empty transfer_config or fsoe_config parameter!";
+    RCLCPP_FATAL(
+      rclcpp::get_logger("EthercatBusManager"), msg.c_str());
+    throw std::runtime_error(msg);
+  }
+
+  std::vector<ethercat_interface::EcTransferNet> transfer_nets;
+  ethercat_interface::EcTransferNet transfer_net;
+
+  if (config["nets"]) {
+    for (const auto & net : config["nets"]) {
+      transfer_net.reset(net["name"].as<std::string>());
+      if (net["safety_master"]) {
+        transfer_net.master = net["safety_master"].as<std::string>();
+      }
+      if (net["transfer_master"]) {
+        transfer_net.master = net["transfer_master"].as<std::string>();
+      }
+      for (const auto & transfer : net["transfers"]) {
+        ethercat_interface::EcTransferEntry transfer_entry;
+        if (!transfer["size"]) {
+          std::string msg = "ERROR: transfer n°" + std::to_string(transfer_nets.size()) +
+            " of net " +
+            transfer_net.name + " : definition without «size» parameter";
+          RCLCPP_FATAL(
+            rclcpp::get_logger("EthercatBusManager"), msg.c_str());
+          throw std::runtime_error(msg);
+        }
+        if (!transfer["in"]) {
+          std::string msg = "ERROR: transfer n°" + std::to_string(transfer_nets.size()) +
+            " of net " +
+            transfer_net.name + " : definition without «in» parameter";
+          RCLCPP_FATAL(
+            rclcpp::get_logger("EthercatBusManager"), msg.c_str());
+          throw std::runtime_error(msg);
+        }
+        if (!transfer["out"]) {
+          std::string msg = "ERROR: transfer n°" + std::to_string(transfer_nets.size()) +
+            " of net " +
+            transfer_net.name + " : definition without «out» parameter";
+          RCLCPP_FATAL(
+            rclcpp::get_logger("EthercatBusManager"), msg.c_str());
+          throw std::runtime_error(msg);
+        }
+        transfer_entry.size = transfer["size"].as<size_t>();
+        getTransferMemoryInfo(
+          transfer["in"], transfer_entry.input,
+          "in", transfer_net.name);
+        getTransferMemoryInfo(
+          transfer["out"], transfer_entry.output,
+          "out", transfer_net.name);
+        transfer_net.transfers.push_back(transfer_entry);
+      }
+      transfer_nets.push_back(transfer_net);
+    }
+  }
+
+  return transfer_nets;
+}
+
+}  // namespace ethercat_driver

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -77,7 +77,7 @@ CallbackReturn EthercatDriver::on_init(
   for (uint j = 0; j < info_.joints.size(); j++) {
     RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "joints");
     // check all joints for EC modules and load into ec_modules_
-    auto module_params = EthercatRos2ControlXmlParser::getEcModuleParam(
+    auto module_params = getEcModuleParam(
       info_.original_xml, info_.joints[j].name, "joint");
     for (auto i = 0ul; i < module_params.size(); i++) {
       for (auto k = 0ul; k < info_.joints[j].state_interfaces.size(); k++) {
@@ -89,8 +89,13 @@ CallbackReturn EthercatDriver::on_init(
           info_.joints[j].command_interfaces[k].name] = std::to_string(k);
       }
       configured_modules.push_back(
-        {module_params[i], &hw_joint_states_[j], &hw_joint_commands_[j],
-          info_.joints[j].name, "Joint", i + 1});
+        ConfiguredEcModule{
+          .parameters = module_params[i],
+          .state_interface = &hw_joint_states_[j],
+          .command_interface = &hw_joint_commands_[j],
+          .component_name = info_.joints[j].name,
+          .module_type = "Joint",
+          .module_number = i + 1});
     }
   }
 
@@ -98,7 +103,7 @@ CallbackReturn EthercatDriver::on_init(
   for (uint g = 0; g < info_.gpios.size(); g++) {
     RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "gpios");
     // check all gpios for EC modules and load into ec_modules_
-    auto module_params = EthercatRos2ControlXmlParser::getEcModuleParam(
+    auto module_params = getEcModuleParam(
       info_.original_xml, info_.gpios[g].name, "gpio");
     for (auto i = 0ul; i < module_params.size(); i++) {
       for (auto k = 0ul; k < info_.gpios[g].state_interfaces.size(); k++) {
@@ -110,8 +115,13 @@ CallbackReturn EthercatDriver::on_init(
           info_.gpios[g].command_interfaces[k].name] = std::to_string(k);
       }
       configured_modules.push_back(
-        {module_params[i], &hw_gpio_states_[g], &hw_gpio_commands_[g],
-          info_.gpios[g].name, "GPIO", i + 1});
+        ConfiguredEcModule{
+          .parameters = module_params[i],
+          .state_interface = &hw_gpio_states_[g],
+          .command_interface = &hw_gpio_commands_[g],
+          .component_name = info_.gpios[g].name,
+          .module_type = "GPIO",
+          .module_number = i + 1});
     }
   }
 
@@ -119,7 +129,7 @@ CallbackReturn EthercatDriver::on_init(
   for (uint s = 0; s < info_.sensors.size(); s++) {
     RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "sensors");
     // check all sensors for EC modules and load into ec_modules_
-    auto module_params = EthercatRos2ControlXmlParser::getEcModuleParam(
+    auto module_params = getEcModuleParam(
       info_.original_xml, info_.sensors[s].name, "sensor");
     for (auto i = 0ul; i < module_params.size(); i++) {
       for (auto k = 0ul; k < info_.sensors[s].state_interfaces.size(); k++) {
@@ -131,8 +141,13 @@ CallbackReturn EthercatDriver::on_init(
           info_.sensors[s].command_interfaces[k].name] = std::to_string(k);
       }
       configured_modules.push_back(
-        {module_params[i], &hw_sensor_states_[s], &hw_sensor_commands_[s],
-          info_.sensors[s].name, "Sensor", i + 1});
+        ConfiguredEcModule{
+          .parameters = module_params[i],
+          .state_interface = &hw_sensor_states_[s],
+          .command_interface = &hw_sensor_commands_[s],
+          .component_name = info_.sensors[s].name,
+          .module_type = "Sensor",
+          .module_number = i + 1});
     }
   }
 

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -14,79 +14,15 @@
 
 #include "ethercat_driver/ethercat_driver.hpp"
 
-#include <tinyxml2.h>
+#include <limits>
 #include <string>
-#include <regex>
 
+#include "ethercat_driver/ethercat_ros2_control_xml_parser.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 namespace ethercat_driver
 {
-
-unsigned int uint_from_string(const std::string & str)
-{
-  // Strip leading and trailing whitespaces
-  std::string s = std::regex_replace(str, std::regex("^ +| +$|( ) +"), "$1");
-  // Test if the number is in hexadecimal format
-  if (s.find("0x") == 0) {
-    return std::stoul(s, nullptr, 16);
-  }
-  return std::stoul(s);
-}
-
-void getTransferMemoryInfo(
-  const YAML::Node & element,
-  ethercat_interface::EcMemoryEntry & entry,
-  const std::string & dir,
-  const std::string & transfer_net_name)
-{
-  if (!element["ec_module"]) {
-    std::string msg = "Transfer definition without ec_module entry, net: " +
-      transfer_net_name + " direction: " + dir;
-    throw std::runtime_error(msg);
-  }
-  if (!element["index"]) {
-    std::string msg = "Transfer definition without index entry, net: " +
-      transfer_net_name + " direction: " + dir;
-    throw std::runtime_error(msg);
-  }
-  if (!element["subindex"]) {
-    std::string msg = "Transfer definition without subindex entry, net: " +
-      transfer_net_name + " direction: " + dir;
-    throw std::runtime_error(msg);
-  }
-
-  entry.module_name = element["ec_module"].as<std::string>();
-  entry.index = uint_from_string(element["index"].as<std::string>());
-  entry.subindex = uint_from_string(element["subindex"].as<std::string>());
-}
-
-void throwErrorIfModuleParametersNotFound(
-  const ethercat_interface::EcTransferEntry & transfer,
-  const std::string & module_name,
-  const std::string & transfer_net_name,
-  const std::string & direction)
-{
-  std::string msg = "In transfer net: " + transfer_net_name + ", for transfer " +
-    transfer.to_simple_string() + ", the module name of the " + direction + "( " + module_name +
-    ") among all the recorded modules.";
-  RCLCPP_ERROR(
-    rclcpp::get_logger(
-      "EthercatDriver"), msg.c_str());
-  throw std::runtime_error(msg);
-}
-
-uint16_t EthercatDriver::getAliasOrDefaultAlias(
-  const std::unordered_map<std::string,
-  std::string> & slave_parameters)
-{
-  if (slave_parameters.find("alias") != slave_parameters.end()) {
-    return std::stoul(slave_parameters.at("alias"));
-  } else {
-    return 0;
-  }
-}
 
 CallbackReturn EthercatDriver::on_init(
   const hardware_interface::HardwareComponentInterfaceParams & params)
@@ -94,9 +30,6 @@ CallbackReturn EthercatDriver::on_init(
   if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS) {
     return CallbackReturn::ERROR;
   }
-
-  const std::lock_guard<std::mutex> lock(ec_mutex_);
-  activated_ = false;
 
   // Set state vectors
   hw_joint_states_.resize(info_.joints.size());
@@ -138,13 +71,14 @@ CallbackReturn EthercatDriver::on_init(
       std::numeric_limits<double>::quiet_NaN());
   }
 
+  std::vector<ConfiguredEcModule> configured_modules;
+
   // Setup slave modules defined per joints in the URDF
   for (uint j = 0; j < info_.joints.size(); j++) {
     RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "joints");
     // check all joints for EC modules and load into ec_modules_
-    auto module_params = getEcModuleParam(info_.original_xml, info_.joints[j].name, "joint");
-    ec_module_parameters_.insert(
-      ec_module_parameters_.end(), module_params.begin(), module_params.end());
+    auto module_params = EthercatRos2ControlXmlParser::getEcModuleParam(
+      info_.original_xml, info_.joints[j].name, "joint");
     for (auto i = 0ul; i < module_params.size(); i++) {
       for (auto k = 0ul; k < info_.joints[j].state_interfaces.size(); k++) {
         module_params[i]["state_interface/" +
@@ -154,26 +88,9 @@ CallbackReturn EthercatDriver::on_init(
         module_params[i]["command_interface/" +
           info_.joints[j].command_interfaces[k].name] = std::to_string(k);
       }
-      try {
-        auto module = ec_loader_.createSharedInstance(module_params[i].at("plugin"));
-        if (!module->setupSlave(
-            module_params[i], &hw_joint_states_[j], &hw_joint_commands_[j]))
-        {
-          RCLCPP_FATAL(
-            rclcpp::get_logger("EthercatDriver"),
-            "Setup of Joint module %li FAILED.", i + 1);
-          return CallbackReturn::ERROR;
-        }
-        module->setAliasAndPosition(
-          getAliasOrDefaultAlias(module_params[i]),
-          std::stoul(module_params[i].at("position")));
-        ec_modules_.push_back(module);
-      } catch (pluginlib::PluginlibException & ex) {
-        RCLCPP_FATAL(
-          rclcpp::get_logger("EthercatDriver"),
-          "The plugin of %s failed to load for some reason. Error: %s\n",
-          info_.joints[j].name.c_str(), ex.what());
-      }
+      configured_modules.push_back(
+        {module_params[i], &hw_joint_states_[j], &hw_joint_commands_[j],
+          info_.joints[j].name, "Joint", i + 1});
     }
   }
 
@@ -181,9 +98,8 @@ CallbackReturn EthercatDriver::on_init(
   for (uint g = 0; g < info_.gpios.size(); g++) {
     RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "gpios");
     // check all gpios for EC modules and load into ec_modules_
-    auto module_params = getEcModuleParam(info_.original_xml, info_.gpios[g].name, "gpio");
-    ec_module_parameters_.insert(
-      ec_module_parameters_.end(), module_params.begin(), module_params.end());
+    auto module_params = EthercatRos2ControlXmlParser::getEcModuleParam(
+      info_.original_xml, info_.gpios[g].name, "gpio");
     for (auto i = 0ul; i < module_params.size(); i++) {
       for (auto k = 0ul; k < info_.gpios[g].state_interfaces.size(); k++) {
         module_params[i]["state_interface/" +
@@ -193,26 +109,9 @@ CallbackReturn EthercatDriver::on_init(
         module_params[i]["command_interface/" +
           info_.gpios[g].command_interfaces[k].name] = std::to_string(k);
       }
-      try {
-        auto module = ec_loader_.createSharedInstance(module_params[i].at("plugin"));
-        if (!module->setupSlave(
-            module_params[i], &hw_gpio_states_[g], &hw_gpio_commands_[g]))
-        {
-          RCLCPP_FATAL(
-            rclcpp::get_logger("EthercatDriver"),
-            "Setup of GPIO module %li FAILED.", i + 1);
-          return CallbackReturn::ERROR;
-        }
-        module->setAliasAndPosition(
-          getAliasOrDefaultAlias(module_params[i]),
-          std::stoul(module_params[i].at("position")));
-        ec_modules_.push_back(module);
-      } catch (pluginlib::PluginlibException & ex) {
-        RCLCPP_FATAL(
-          rclcpp::get_logger("EthercatDriver"),
-          "The plugin of %s failed to load for some reason. Error: %s\n",
-          info_.gpios[g].name.c_str(), ex.what());
-      }
+      configured_modules.push_back(
+        {module_params[i], &hw_gpio_states_[g], &hw_gpio_commands_[g],
+          info_.gpios[g].name, "GPIO", i + 1});
     }
   }
 
@@ -220,9 +119,8 @@ CallbackReturn EthercatDriver::on_init(
   for (uint s = 0; s < info_.sensors.size(); s++) {
     RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "sensors");
     // check all sensors for EC modules and load into ec_modules_
-    auto module_params = getEcModuleParam(info_.original_xml, info_.sensors[s].name, "sensor");
-    ec_module_parameters_.insert(
-      ec_module_parameters_.end(), module_params.begin(), module_params.end());
+    auto module_params = EthercatRos2ControlXmlParser::getEcModuleParam(
+      info_.original_xml, info_.sensors[s].name, "sensor");
     for (auto i = 0ul; i < module_params.size(); i++) {
       for (auto k = 0ul; k < info_.sensors[s].state_interfaces.size(); k++) {
         module_params[i]["state_interface/" +
@@ -232,140 +130,14 @@ CallbackReturn EthercatDriver::on_init(
         module_params[i]["command_interface/" +
           info_.sensors[s].command_interfaces[k].name] = std::to_string(k);
       }
-      try {
-        auto module = ec_loader_.createSharedInstance(module_params[i].at("plugin"));
-        if (!module->setupSlave(
-            module_params[i], &hw_sensor_states_[s], &hw_sensor_commands_[s]))
-        {
-          RCLCPP_FATAL(
-            rclcpp::get_logger("EthercatDriver"),
-            "Setup of Sensor module %li FAILED.", i + 1);
-          return CallbackReturn::ERROR;
-        }
-        module->setAliasAndPosition(
-          getAliasOrDefaultAlias(module_params[i]),
-          std::stoul(module_params[i].at("position")));
-        ec_modules_.push_back(module);
-      } catch (pluginlib::PluginlibException & ex) {
-        RCLCPP_FATAL(
-          rclcpp::get_logger("EthercatDriver"),
-          "The plugin of %s failed to load for some reason. Error: %s\n",
-          info_.sensors[s].name.c_str(), ex.what());
-      }
+      configured_modules.push_back(
+        {module_params[i], &hw_sensor_states_[s], &hw_sensor_commands_[s],
+          info_.sensors[s].name, "Sensor", i + 1});
     }
   }
 
-  RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "Got %li modules", ec_modules_.size());
-
-  // Check if a transfer configuration is provided
-  if (info_.hardware_parameters.find("fsoe_config") != info_.hardware_parameters.end() ||
-    info_.hardware_parameters.find("transfer_config") != info_.hardware_parameters.end())
-  {
-    RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "Transfer configuration detected, ...");
-
-    YAML::Node config;
-    // Load the transfer config file
-    loadTransferConfigYamlFile(config);
-
-    // Parse transfer modules from the transfer yaml file
-    auto transfer_module_params = getEcTransferModuleParam(config);
-
-    // Append the transfer modules parameters to the list of modules parameters
-    size_t idx_1st = ec_module_parameters_.size();
-    ec_module_parameters_.insert(
-      ec_module_parameters_.end(), transfer_module_params.begin(), transfer_module_params.end());
-    for (size_t i = 0; i < transfer_module_params.size(); i++) {
-      ec_transfer_slaves_.push_back(idx_1st + i);
-    }
-
-    // Parse transfer nets from the transfer yaml file
-    ec_transfer_nets_ = getEcTransferNets(config);
-
-    // Append the transfer modules to the list of modules and load them
-    for (const auto & transfer_module_param : transfer_module_params) {
-      try {
-        auto ec_module = ec_loader_.createSharedInstance(transfer_module_param.at("plugin"));
-        if (!ec_module->setupSlave(
-            transfer_module_param, &empty_interface_, &empty_interface_))
-        {
-          const std::string & module_name = transfer_module_param.at("name");
-          RCLCPP_FATAL(
-            rclcpp::get_logger("EthercatDriver"),
-            "Setup of transfer only module %s FAILED.", module_name.c_str() );
-          return CallbackReturn::ERROR;
-        }
-
-        auto idx = ec_modules_.size();
-        ec_module->setAliasAndPosition(
-          getAliasOrDefaultAlias(transfer_module_param),
-          std::stoul(transfer_module_param.at("position")));
-        ec_modules_.push_back(ec_module);
-        ec_transfer_slaves_.push_back(idx);
-      } catch (const pluginlib::PluginlibException & ex) {
-        const std::string & module_name = transfer_module_param.at("name");
-        RCLCPP_ERROR(
-          rclcpp::get_logger(
-            "EthercatDriver"),
-          "The plugin failed to load for transfer module %s. Error: %s\n",
-          module_name.c_str(), ex.what());
-      }
-    }
-
-    // Find all masters from the nets
-    {
-      std::vector<std::string> master_names;
-      for (const auto & net : ec_transfer_nets_) {
-        master_names.push_back(net.master);
-      }
-      for (size_t i = 0; i < ec_module_parameters_.size(); i++) {
-        if (std::find(
-            master_names.begin(), master_names.end(),
-            ec_module_parameters_[i].at("name")) !=
-          master_names.end())
-        {
-          ec_transfer_masters_.push_back(i);
-        }
-      }
-    }
-
-    // Identify (alias,position) all the modules participating in transfers
-    for (auto & net : ec_transfer_nets_) {
-      for (auto & transfer : net.transfers) {
-        // Update each EcMemoryEntry with the alias and position of the module
-        size_t in_idx = ec_module_parameters_.size();
-        for (in_idx = 0; in_idx < ec_module_parameters_.size(); ++in_idx) {
-          if (ec_module_parameters_[in_idx].at("name") == transfer.input.module_name) {
-            break;
-          }
-        }
-        size_t out_idx = ec_module_parameters_.size();
-        for (out_idx = 0; out_idx < ec_module_parameters_.size(); ++out_idx) {
-          if (ec_module_parameters_[out_idx].at("name") == transfer.output.module_name) {
-            break;
-          }
-        }
-        if (in_idx == ec_module_parameters_.size()) {
-          throwErrorIfModuleParametersNotFound(
-            transfer, transfer.input.module_name, net.name, "input");
-        }
-        if (out_idx == ec_module_parameters_.size()) {
-          throwErrorIfModuleParametersNotFound(
-            transfer, transfer.output.module_name, net.name, "output");
-        }
-
-        const auto & input_module = ec_modules_[in_idx];
-        const auto & output_module = ec_modules_[out_idx];
-
-        transfer.input.alias = input_module->alias_;
-        transfer.input.position = input_module->position_;
-        transfer.output.alias = output_module->alias_;
-        transfer.output.position = output_module->position_;
-      }
-    }
-
-    RCLCPP_INFO(
-      rclcpp::get_logger("EthercatDriver"),
-      "Transfer configuration loaded successfully!");
+  if (!bus_manager_.configureModules(info_.hardware_parameters, configured_modules)) {
+    return CallbackReturn::ERROR;
   }
 
   return CallbackReturn::SUCCESS;
@@ -452,133 +224,12 @@ EthercatDriver::export_command_interfaces()
   return command_interfaces;
 }
 
-CallbackReturn EthercatDriver::setupMaster()
-{
-  unsigned int master_id = 666;
-  // Get master id
-  if (info_.hardware_parameters.find("master_id") == info_.hardware_parameters.end()) {
-    // Master id was not provided, default to 0
-    master_id = 0;
-  } else {
-    try {
-      master_id = std::stoul(info_.hardware_parameters["master_id"]);
-    } catch (std::exception & e) {
-      RCLCPP_FATAL(
-        rclcpp::get_logger("EthercatDriver"), "Invalid master id (%s)!", e.what());
-      return CallbackReturn::ERROR;
-    }
-  }
-  master_ = std::make_shared<ethercat_interface::EcMaster>(master_id);
-
-  return CallbackReturn::SUCCESS;
-}
-
-CallbackReturn EthercatDriver::configNetwork()
-{
-  // Get control frequency
-  if (info_.hardware_parameters.find("control_frequency") == info_.hardware_parameters.end()) {
-    // Control frequency was not provided, default to 100 Hz
-    control_frequency_ = 100.0;
-  } else {
-    try {
-      control_frequency_ = std::stod(info_.hardware_parameters["control_frequency"]);
-    } catch (std::exception & e) {
-      RCLCPP_FATAL(
-        rclcpp::get_logger("EthercatDriver"), "Invalid control frequency (%s)!", e.what());
-      return CallbackReturn::ERROR;
-    }
-  }
-
-  // start EC and wait until state operative
-
-  master_->setCtrlFrequency(control_frequency_);
-
-  for (auto i = 0ul; i < ec_modules_.size(); i++) {
-    master_->addSlave(ec_modules_[i].get());
-  }
-
-  // configure SDO
-  for (auto i = 0ul; i < ec_modules_.size(); i++) {
-    for (auto & sdo : ec_modules_[i]->sdo_config) {
-      uint32_t abort_code;
-      int ret = master_->configSlaveSdo(
-        std::stod(ec_module_parameters_[i]["position"]),
-        sdo,
-        &abort_code);
-      if (ret) {
-        RCLCPP_INFO(
-          rclcpp::get_logger("EthercatDriver"),
-          "Failed to download config SDO for module at position %s with Error: %d",
-          ec_module_parameters_[i]["position"].c_str(),
-          abort_code);
-      }
-    }
-  }
-
-  return CallbackReturn::SUCCESS;
-}
-
 CallbackReturn EthercatDriver::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  const std::lock_guard<std::mutex> lock(ec_mutex_);
-  if (activated_) {
-    RCLCPP_FATAL(rclcpp::get_logger("EthercatDriver"), "Double on_activate()");
+  if (!bus_manager_.activateBus()) {
     return CallbackReturn::ERROR;
   }
-  RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "Starting ...please wait...");
-
-  // setup master
-  setupMaster();
-  // configure network
-  configNetwork();
-
-  if (!master_->activate()) {
-    RCLCPP_ERROR(rclcpp::get_logger("EthercatDriver"), "Activate EcMaster failed");
-    return CallbackReturn::ERROR;
-  }
-  RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "Activated EcMaster!");
-
-  // Configure transfer network if transfer nets are defined
-  if (!ec_transfer_nets_.empty()) {
-    RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "Configuring transfer network...");
-    master_->registerTransferInDomain(ec_transfer_nets_);
-    RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "Transfer network configured!");
-  }
-
-  // start after one second
-  struct timespec t;
-  clock_gettime(CLOCK_MONOTONIC, &t);
-  t.tv_sec++;
-
-  bool running = true;
-  while (running) {
-    // wait until next shot
-    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &t, NULL);
-    // update EtherCAT bus
-
-    master_->update();
-
-    // check if operational
-    bool isAllInit = true;
-    for (auto & module : ec_modules_) {
-      isAllInit = isAllInit && module->initialized();
-    }
-    if (isAllInit) {
-      running = false;
-    }
-    // calculate next shot. carry over nanoseconds into microseconds.
-    t.tv_nsec += master_->getInterval();
-    while (t.tv_nsec >= 1000000000) {
-      t.tv_nsec -= 1000000000;
-      t.tv_sec++;
-    }
-  }
-
-  RCLCPP_INFO(
-    rclcpp::get_logger("EthercatDriver"), "System Successfully started!");
-
-  activated_ = true;
 
   return CallbackReturn::SUCCESS;
 }
@@ -586,16 +237,7 @@ CallbackReturn EthercatDriver::on_activate(
 CallbackReturn EthercatDriver::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  const std::lock_guard<std::mutex> lock(ec_mutex_);
-  activated_ = false;
-
-  RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "Stopping ...please wait...");
-
-  // stop EC and disconnect
-  master_->stop();
-
-  RCLCPP_INFO(
-    rclcpp::get_logger("EthercatDriver"), "System successfully stopped!");
+  bus_manager_.deactivateBus();
 
   return CallbackReturn::SUCCESS;
 }
@@ -604,10 +246,8 @@ hardware_interface::return_type EthercatDriver::read(
   const rclcpp::Time & /*time*/,
   const rclcpp::Duration & /*period*/)
 {
-  // try to lock so we can avoid blocking the read/write loop on the lock.
-  const std::unique_lock<std::mutex> lock(ec_mutex_, std::try_to_lock);
-  if (lock.owns_lock() && activated_) {
-    master_->readData();
+  if (bus_manager_.read() == EthercatCycleResult::kError) {
+    return hardware_interface::return_type::ERROR;
   }
   return hardware_interface::return_type::OK;
 }
@@ -616,251 +256,10 @@ hardware_interface::return_type EthercatDriver::write(
   const rclcpp::Time & /*time*/,
   const rclcpp::Duration & /*period*/)
 {
-  // try to lock so we can avoid blocking the read/write loop on the lock.
-  const std::unique_lock<std::mutex> lock(ec_mutex_, std::try_to_lock);
-  if (lock.owns_lock() && activated_) {
-    master_->writeData();
+  if (bus_manager_.write() == EthercatCycleResult::kError) {
+    return hardware_interface::return_type::ERROR;
   }
   return hardware_interface::return_type::OK;
-}
-
-std::vector<std::unordered_map<std::string, std::string>> EthercatDriver::getEcModuleParam(
-  const std::string & urdf,
-  const std::string & component_name,
-  const std::string & component_type)
-{
-  // Check if everything OK with URDF string
-  if (urdf.empty()) {
-    throw std::runtime_error("empty URDF passed to robot");
-  }
-  tinyxml2::XMLDocument doc;
-  if (!doc.Parse(urdf.c_str()) && doc.Error()) {
-    throw std::runtime_error("invalid URDF passed in to robot parser");
-  }
-  if (doc.Error()) {
-    throw std::runtime_error("invalid URDF passed in to robot parser");
-  }
-
-  tinyxml2::XMLElement * robot_it = doc.RootElement();
-  if (std::string("robot").compare(robot_it->Name())) {
-    throw std::runtime_error("the robot tag is not root element in URDF");
-  }
-
-  const tinyxml2::XMLElement * ros2_control_it = robot_it->FirstChildElement("ros2_control");
-  if (!ros2_control_it) {
-    throw std::runtime_error("no ros2_control tag");
-  }
-
-  std::vector<std::unordered_map<std::string, std::string>> module_params;
-  std::unordered_map<std::string, std::string> module_param;
-
-  while (ros2_control_it) {
-    const auto * ros2_control_child_it = ros2_control_it->FirstChildElement(component_type.c_str());
-    while (ros2_control_child_it) {
-      if (!component_name.compare(ros2_control_child_it->Attribute("name"))) {
-        const auto * ec_module_it = ros2_control_child_it->FirstChildElement("ec_module");
-        while (ec_module_it) {
-          module_param.clear();
-          module_param["name"] = ec_module_it->Attribute("name");
-          const auto * plugin_it = ec_module_it->FirstChildElement("plugin");
-          if (NULL != plugin_it) {
-            module_param["plugin"] = plugin_it->GetText();
-          }
-          const auto * param_it = ec_module_it->FirstChildElement("param");
-          while (param_it) {
-            module_param[param_it->Attribute("name")] = param_it->GetText();
-            param_it = param_it->NextSiblingElement("param");
-          }
-          module_params.push_back(module_param);
-          ec_module_it = ec_module_it->NextSiblingElement("ec_module");
-        }
-      }
-      ros2_control_child_it = ros2_control_child_it->NextSiblingElement(component_type.c_str());
-    }
-    ros2_control_it = ros2_control_it->NextSiblingElement("ros2_control");
-  }
-
-  return module_params;
-}
-
-void EthercatDriver::loadTransferConfigYamlFile(YAML::Node & node, const std::string & path)
-{
-  std::string file_path;
-  if (path.empty()) {
-    // Get the fsoe_config or transfer_config parameter of the ethercat_driver hardware plugin
-    if (info_.hardware_parameters.find("fsoe_config") == info_.hardware_parameters.end() &&
-      info_.hardware_parameters.find("transfer_config") == info_.hardware_parameters.end() )
-    {
-      std::string msg("transfer_config or fsoe_config parameter is missing!");
-      // Transfer (or fsoe) config file was not provided
-      RCLCPP_FATAL(
-        rclcpp::get_logger("EthercatDriver"), msg.c_str());
-      throw std::runtime_error(msg);
-    }
-    if (info_.hardware_parameters.find("fsoe_config") != info_.hardware_parameters.end() &&
-      info_.hardware_parameters.find("transfer_config") != info_.hardware_parameters.end())
-    {
-      std::string msg(
-        "Both transfer_config and fsoe_config parameters are provided! Please provide only one "
-        "of them.");
-      RCLCPP_FATAL(
-        rclcpp::get_logger("EthercatDriver"), msg.c_str());
-      throw std::runtime_error(msg);
-    }
-    if (info_.hardware_parameters.find("fsoe_config") != info_.hardware_parameters.end() ) {
-      std::string msg("The fsoe_config parameter is deprecated. "
-        "Please use transfer_config instead.");
-      RCLCPP_WARN(
-        rclcpp::get_logger("EthercatDriver"), msg.c_str());
-      file_path = info_.hardware_parameters.at("fsoe_config");
-    }
-    if (info_.hardware_parameters.find("transfer_config") != info_.hardware_parameters.end()) {
-      file_path = info_.hardware_parameters.at("transfer_config");
-    }
-  } else {
-    file_path = path;
-  }
-
-  try {
-    node = YAML::LoadFile(file_path);
-  } catch (const YAML::ParserException & ex) {
-    std::string msg =
-      std::string(
-      "EthercatDriver : failed to load transfer configuration "
-      "(YAML file is incorrect): ") + std::string(ex.what());
-    RCLCPP_FATAL(
-      rclcpp::get_logger("EthercatDriver"), msg.c_str() );
-    throw std::runtime_error(msg);
-  } catch (const YAML::BadFile & ex) {
-    std::string msg =
-      std::string(
-      "EthercatDriver : failed to load transfer configuration "
-      "(file path is incorrect or file is damaged): " + std::string(ex.what()));
-    RCLCPP_FATAL(
-      rclcpp::get_logger("EthercatDriver"), msg.c_str() );
-    throw std::runtime_error(msg);
-  } catch (std::exception & e) {
-    std::string msg =
-      std::string(
-      "EthercatDriver : error while loading transfer configuration: ") + std::string(e.what());
-    RCLCPP_FATAL(
-      rclcpp::get_logger("EthercatDriver"), msg.c_str() );
-    throw std::runtime_error(msg);
-  }
-}
-
-std::vector<std::unordered_map<std::string, std::string>> EthercatDriver::getEcTransferModuleParam(
-  const YAML::Node & config)
-{
-  if (0 == config.size() ) {
-    std::string msg = "Empty transfer_config or fsoe_config parameter!";
-    RCLCPP_FATAL(
-      rclcpp::get_logger("EthercatDriver"), msg.c_str());
-    throw std::runtime_error(msg);
-  }
-  std::vector<std::unordered_map<std::string, std::string>> module_params;
-  std::unordered_map<std::string, std::string> module_param;
-
-  // It is possible that modules are only involved in transfers and hence
-  // not declared in the ros2_control xacro file.
-  // This is a common situation with modules only involved in safety
-  // operations. In this case, it is necessary to find the plugin to load,
-  // the position and the alias for those slaves.
-  if (config["transfer_modules"]) {
-    for (const auto & module : config["transfer_modules"]) {
-      module_param.clear();
-      module_param["name"] = module["name"].as<std::string>();
-      module_param["plugin"] = module["plugin"].as<std::string>();
-      for (const auto & param : module["parameters"]) {
-        module_param[param.first.as<std::string>()] = param.second.as<std::string>();
-      }
-      module_params.push_back(module_param);
-    }
-  }
-
-  if (config["safety_modules"]) {
-    for (const auto & module : config["safety_modules"]) {
-      module_param.clear();
-      module_param["name"] = module["name"].as<std::string>();
-      module_param["plugin"] = module["plugin"].as<std::string>();
-      for (const auto & param : module["parameters"]) {
-        module_param[param.first.as<std::string>()] = param.second.as<std::string>();
-      }
-      module_params.push_back(module_param);
-    }
-  }
-
-  return module_params;
-}
-
-std::vector<ethercat_interface::EcTransferNet> EthercatDriver::getEcTransferNets(
-  const YAML::Node & config)
-{
-  if (0 == config.size() ) {
-    std::string msg = "Empty transfer_config or fsoe_config parameter!";
-    RCLCPP_FATAL(
-      rclcpp::get_logger("EthercatDriver"), msg.c_str());
-    throw std::runtime_error(msg);
-  }
-
-  std::vector<ethercat_interface::EcTransferNet> transfer_nets;
-  ethercat_interface::EcTransferNet transfer_net;
-
-  if (config["nets"]) {
-    for (const auto & net : config["nets"]) {
-      transfer_net.reset(net["name"].as<std::string>());
-      if (net["safety_master"]) {
-        transfer_net.master = net["safety_master"].as<std::string>();
-      }
-      if (net["transfer_master"]) {
-        transfer_net.master = net["transfer_master"].as<std::string>();
-      }
-      for (const auto & transfer : net["transfers"]) {
-        ethercat_interface::EcTransferEntry transfer_entry;
-        if (!transfer["size"]) {
-          std::string msg = "ERROR: transfer n°" + std::to_string(transfer_nets.size()) +
-            " of net " +
-            transfer_net.name + " : definition without «size» parameter";
-          RCLCPP_FATAL(
-            rclcpp::get_logger("EthercatDriver"), msg.c_str());
-          throw std::runtime_error(msg);
-        }
-        if (!transfer["in"]) {
-          std::string msg = "ERROR: transfer n°" + std::to_string(transfer_nets.size()) +
-            " of net " +
-            transfer_net.name + " : definition without «in» parameter";
-          RCLCPP_FATAL(
-            rclcpp::get_logger("EthercatDriver"), msg.c_str());
-          throw std::runtime_error(msg);
-        }
-        if (!transfer["out"]) {
-          std::string msg = "ERROR: transfer n°" + std::to_string(transfer_nets.size()) +
-            " of net " +
-            transfer_net.name + " : definition without «out» parameter";
-          RCLCPP_FATAL(
-            rclcpp::get_logger("EthercatDriver"), msg.c_str());
-          throw std::runtime_error(msg);
-        }
-        transfer_entry.size = transfer["size"].as<size_t>();
-        getTransferMemoryInfo(
-          transfer["in"], transfer_entry.input,
-          "in", transfer_net.name);
-        getTransferMemoryInfo(
-          transfer["out"], transfer_entry.output,
-          "out", transfer_net.name);
-        transfer_net.transfers.push_back(transfer_entry);
-      }
-      transfer_nets.push_back(transfer_net);
-    }
-  }
-
-  return transfer_nets;
-}
-
-void EthercatDriver::configTransferNetwork()
-{
-  // This method can be used for additional transfer network configuration if needed
-  // Currently, transfer network configuration is handled in on_activate()
 }
 
 }  // namespace ethercat_driver

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -14,8 +14,10 @@
 
 #include "ethercat_driver/ethercat_driver.hpp"
 
+#include <exception>
 #include <limits>
 #include <string>
+#include <unordered_map>
 
 #include "ethercat_driver/ethercat_ros2_control_xml_parser.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
@@ -42,6 +44,71 @@ ConfiguredEcModule make_configured_ec_module(
   module.module_type = std::move(module_type);
   module.module_number = module_number;
   return module;
+}
+
+bool configure_ethercat_bus_config(
+  const std::unordered_map<std::string, std::string> & hardware_parameters,
+  EthercatBusConfig & bus_config)
+{
+  unsigned int master_id = 666;
+  // Get master id
+  if (hardware_parameters.find("master_id") == hardware_parameters.end()) {
+    // Master id was not provided, default to 0
+    master_id = 0;
+  } else {
+    try {
+      master_id = std::stoul(hardware_parameters.at("master_id"));
+    } catch (std::exception & e) {
+      RCLCPP_FATAL(
+        rclcpp::get_logger("EthercatDriver"), "Invalid master id (%s)!", e.what());
+      return false;
+    }
+  }
+  bus_config.master_id = master_id;
+
+  // Get control frequency
+  if (hardware_parameters.find("control_frequency") == hardware_parameters.end()) {
+    // Control frequency was not provided, default to 100 Hz
+    bus_config.control_frequency = 100.0;
+  } else {
+    try {
+      bus_config.control_frequency = std::stod(hardware_parameters.at("control_frequency"));
+    } catch (std::exception & e) {
+      RCLCPP_FATAL(
+        rclcpp::get_logger("EthercatDriver"), "Invalid control frequency (%s)!", e.what());
+      return false;
+    }
+  }
+
+  const auto transfer_config = hardware_parameters.find("transfer_config");
+  const auto fsoe_config = hardware_parameters.find("fsoe_config");
+  if (transfer_config != hardware_parameters.end() && fsoe_config != hardware_parameters.end()) {
+    RCLCPP_FATAL(
+      rclcpp::get_logger("EthercatDriver"),
+      "Both transfer_config and fsoe_config parameters are provided! Please provide only one "
+      "of them.");
+    return false;
+  }
+  if (transfer_config != hardware_parameters.end() && transfer_config->second.empty()) {
+    RCLCPP_FATAL(
+      rclcpp::get_logger("EthercatDriver"), "Empty transfer_config or fsoe_config parameter!");
+    return false;
+  }
+  if (fsoe_config != hardware_parameters.end() && fsoe_config->second.empty()) {
+    RCLCPP_FATAL(
+      rclcpp::get_logger("EthercatDriver"), "Empty transfer_config or fsoe_config parameter!");
+    return false;
+  }
+
+  if (transfer_config != hardware_parameters.end()) {
+    bus_config.transfer_config = transfer_config->second;
+  }
+
+  if (fsoe_config != hardware_parameters.end()) {
+    bus_config.fsoe_config = fsoe_config->second;
+  }
+
+  return true;
 }
 
 }  // namespace
@@ -173,7 +240,12 @@ CallbackReturn EthercatDriver::on_init(
     }
   }
 
-  if (!bus_manager_.configureModules(info_.hardware_parameters, configured_modules)) {
+  EthercatBusConfig bus_config;
+  if (!configure_ethercat_bus_config(info_.hardware_parameters, bus_config)) {
+    return CallbackReturn::ERROR;
+  }
+
+  if (!bus_manager_.configureModules(bus_config, configured_modules)) {
     return CallbackReturn::ERROR;
   }
 

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -23,6 +23,28 @@
 
 namespace ethercat_driver
 {
+namespace
+{
+
+ConfiguredEcModule make_configured_ec_module(
+  std::unordered_map<std::string, std::string> parameters,
+  std::vector<double> * state_interface,
+  std::vector<double> * command_interface,
+  std::string component_name,
+  std::string module_type,
+  size_t module_number)
+{
+  ConfiguredEcModule module;
+  module.parameters = std::move(parameters);
+  module.state_interface = state_interface;
+  module.command_interface = command_interface;
+  module.component_name = std::move(component_name);
+  module.module_type = std::move(module_type);
+  module.module_number = module_number;
+  return module;
+}
+
+}  // namespace
 
 CallbackReturn EthercatDriver::on_init(
   const hardware_interface::HardwareComponentInterfaceParams & params)
@@ -89,13 +111,13 @@ CallbackReturn EthercatDriver::on_init(
           info_.joints[j].command_interfaces[k].name] = std::to_string(k);
       }
       configured_modules.push_back(
-        ConfiguredEcModule{
-          .parameters = module_params[i],
-          .state_interface = &hw_joint_states_[j],
-          .command_interface = &hw_joint_commands_[j],
-          .component_name = info_.joints[j].name,
-          .module_type = "Joint",
-          .module_number = i + 1});
+        make_configured_ec_module(
+          module_params[i],
+          &hw_joint_states_[j],
+          &hw_joint_commands_[j],
+          info_.joints[j].name,
+          "Joint",
+          i + 1));
     }
   }
 
@@ -115,13 +137,13 @@ CallbackReturn EthercatDriver::on_init(
           info_.gpios[g].command_interfaces[k].name] = std::to_string(k);
       }
       configured_modules.push_back(
-        ConfiguredEcModule{
-          .parameters = module_params[i],
-          .state_interface = &hw_gpio_states_[g],
-          .command_interface = &hw_gpio_commands_[g],
-          .component_name = info_.gpios[g].name,
-          .module_type = "GPIO",
-          .module_number = i + 1});
+        make_configured_ec_module(
+          module_params[i],
+          &hw_gpio_states_[g],
+          &hw_gpio_commands_[g],
+          info_.gpios[g].name,
+          "GPIO",
+          i + 1));
     }
   }
 
@@ -141,13 +163,13 @@ CallbackReturn EthercatDriver::on_init(
           info_.sensors[s].command_interfaces[k].name] = std::to_string(k);
       }
       configured_modules.push_back(
-        ConfiguredEcModule{
-          .parameters = module_params[i],
-          .state_interface = &hw_sensor_states_[s],
-          .command_interface = &hw_sensor_commands_[s],
-          .component_name = info_.sensors[s].name,
-          .module_type = "Sensor",
-          .module_number = i + 1});
+        make_configured_ec_module(
+          module_params[i],
+          &hw_sensor_states_[s],
+          &hw_sensor_commands_[s],
+          info_.sensors[s].name,
+          "Sensor",
+          i + 1));
     }
   }
 

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -30,16 +30,16 @@ namespace
 
 ConfiguredEcModule make_configured_ec_module(
   std::unordered_map<std::string, std::string> parameters,
-  std::vector<double> * state_interface,
-  std::vector<double> * command_interface,
+  std::vector<double> * input_values,
+  std::vector<double> * output_values,
   std::string component_name,
   std::string module_type,
   size_t module_number)
 {
   ConfiguredEcModule module;
   module.parameters = std::move(parameters);
-  module.state_interface = state_interface;
-  module.command_interface = command_interface;
+  module.input_values = input_values;
+  module.output_values = output_values;
   module.component_name = std::move(component_name);
   module.module_type = std::move(module_type);
   module.module_number = module_number;

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -18,6 +18,7 @@
 #include <limits>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "ethercat_driver/ethercat_ros2_control_xml_parser.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"

--- a/ethercat_driver/src/ethercat_ros2_control_xml_parser.cpp
+++ b/ethercat_driver/src/ethercat_ros2_control_xml_parser.cpp
@@ -1,0 +1,85 @@
+// Copyright 2022 ICUBE Laboratory, University of Strasbourg
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ethercat_driver/ethercat_ros2_control_xml_parser.hpp"
+
+#include <stdexcept>
+#include <string>
+
+#include <tinyxml2.h>
+
+namespace ethercat_driver
+{
+
+std::vector<std::unordered_map<std::string, std::string>>
+EthercatRos2ControlXmlParser::getEcModuleParam(
+  const std::string & urdf,
+  const std::string & component_name,
+  const std::string & component_type)
+{
+  // Check if everything OK with URDF string
+  if (urdf.empty()) {
+    throw std::runtime_error("empty URDF passed to robot");
+  }
+  tinyxml2::XMLDocument doc;
+  if (!doc.Parse(urdf.c_str()) && doc.Error()) {
+    throw std::runtime_error("invalid URDF passed in to robot parser");
+  }
+  if (doc.Error()) {
+    throw std::runtime_error("invalid URDF passed in to robot parser");
+  }
+
+  tinyxml2::XMLElement * robot_it = doc.RootElement();
+  if (std::string("robot").compare(robot_it->Name())) {
+    throw std::runtime_error("the robot tag is not root element in URDF");
+  }
+
+  const tinyxml2::XMLElement * ros2_control_it = robot_it->FirstChildElement("ros2_control");
+  if (!ros2_control_it) {
+    throw std::runtime_error("no ros2_control tag");
+  }
+
+  std::vector<std::unordered_map<std::string, std::string>> module_params;
+  std::unordered_map<std::string, std::string> module_param;
+
+  while (ros2_control_it) {
+    const auto * ros2_control_child_it = ros2_control_it->FirstChildElement(component_type.c_str());
+    while (ros2_control_child_it) {
+      if (!component_name.compare(ros2_control_child_it->Attribute("name"))) {
+        const auto * ec_module_it = ros2_control_child_it->FirstChildElement("ec_module");
+        while (ec_module_it) {
+          module_param.clear();
+          module_param["name"] = ec_module_it->Attribute("name");
+          const auto * plugin_it = ec_module_it->FirstChildElement("plugin");
+          if (NULL != plugin_it) {
+            module_param["plugin"] = plugin_it->GetText();
+          }
+          const auto * param_it = ec_module_it->FirstChildElement("param");
+          while (param_it) {
+            module_param[param_it->Attribute("name")] = param_it->GetText();
+            param_it = param_it->NextSiblingElement("param");
+          }
+          module_params.push_back(module_param);
+          ec_module_it = ec_module_it->NextSiblingElement("ec_module");
+        }
+      }
+      ros2_control_child_it = ros2_control_child_it->NextSiblingElement(component_type.c_str());
+    }
+    ros2_control_it = ros2_control_it->NextSiblingElement("ros2_control");
+  }
+
+  return module_params;
+}
+
+}  // namespace ethercat_driver

--- a/ethercat_driver/src/ethercat_ros2_control_xml_parser.cpp
+++ b/ethercat_driver/src/ethercat_ros2_control_xml_parser.cpp
@@ -22,8 +22,7 @@
 namespace ethercat_driver
 {
 
-std::vector<std::unordered_map<std::string, std::string>>
-EthercatRos2ControlXmlParser::getEcModuleParam(
+std::vector<std::unordered_map<std::string, std::string>> getEcModuleParam(
   const std::string & urdf,
   const std::string & component_name,
   const std::string & component_type)

--- a/ethercat_driver/src/ethercat_ros2_control_xml_parser.cpp
+++ b/ethercat_driver/src/ethercat_ros2_control_xml_parser.cpp
@@ -14,10 +14,10 @@
 
 #include "ethercat_driver/ethercat_ros2_control_xml_parser.hpp"
 
+#include <tinyxml2.h>
+
 #include <stdexcept>
 #include <string>
-
-#include <tinyxml2.h>
 
 namespace ethercat_driver
 {

--- a/ethercat_driver/test/test_ethercat_safety_driver.cpp
+++ b/ethercat_driver/test/test_ethercat_safety_driver.cpp
@@ -22,12 +22,13 @@
 #include <fstream>
 #include <sstream>
 #include <filesystem>
+#include <set>
 
-#include "testHelper_ethercat_safety_driver.hpp"
+#include "ethercat_driver/ethercat_bus_manager.hpp"
 
 TEST(TestEthercatSafetyDriver, getEcTransferModuleParam)
 {
-  ethercat_driver::TestHelperEthercatSafetyDriver driver;
+  ethercat_driver::EthercatBusManager driver;
   std::filesystem::path dir = TEST_RESOURCES_DIRECTORY;
   const std::string test_config_path = dir / "test_config_ethercat_safety.yaml";
 
@@ -52,7 +53,7 @@ TEST(TestEthercatSafetyDriver, getEcTransferModuleParam)
 
 TEST(TestEthercatSafetyDriver, getEcTransferNet)
 {
-  ethercat_driver::TestHelperEthercatSafetyDriver driver;
+  ethercat_driver::EthercatBusManager driver;
   std::string yaml;
   {
     std::filesystem::path dir = TEST_RESOURCES_DIRECTORY;
@@ -162,7 +163,7 @@ TEST(TestEthercatSafetyDriver, getEcTransferNet)
 
 TEST(TestEthercatSafetyDriver, estopParseConfigFile)
 {
-  ethercat_driver::TestHelperEthercatSafetyDriver driver;
+  ethercat_driver::EthercatBusManager driver;
   std::string yaml;
   {
     std::filesystem::path dir = TEST_RESOURCES_DIRECTORY;

--- a/ethercat_interface/src/ec_master.cpp
+++ b/ethercat_interface/src/ec_master.cpp
@@ -75,6 +75,10 @@ EcMaster::~EcMaster()
       delete domain.second;
     }
   }
+  // Release the EtherCAT master so the kernel module can be reused
+  if (master_) {
+    ecrt_release_master(master_);
+  }
 }
 
 void EcMaster::addSlave(uint16_t alias, uint16_t position, EcSlave * slave)


### PR DESCRIPTION
This PR proposes to extract the core logic from `ethercat_driver.cpp` into two modules which are in itself largely ROS2-independent and can be re-used in different hardware interface implementations (or even without ros2_control):

* A new `EthercatBusManager` which handles configuration, activation, reading, writing to/from the EtherCAT bus. That was previously all done in the `EthercatDriver` (ros2_control hardware interface).
* XML parsing logic for `<ec_module>` blocks has been extracted to a separate parser function in `ethercat_ros2_control_xml_parser.hpp/cpp`

What remains ROS2 related (which is fine, we mainly want to extract from ros2_control hardware interface, so we can re-use in a different hardware interface!):
* ROS2 logging
* Pluginlib for loading `ECSlave` plugins. Reasoning: while plugins are part of the ROS2 ecosystem, it is a generic and very useful concept (it would actually be better if it lived outside the ROS2 ecosystem). We want the user to be able to load their own slaves through plugins. So we'll keep using this inside `EthercatBusManager` even if it's ROS2.

> [!IMPORTANT]
> Merge after #221 !

> [!IMPORTANT]
> This PR is focussed mainly on **moving code**, without changing logic significantly (though a few minor changes were made, see sections below).
> However the diff still looks horrendous because code moving to new files can't be visualized well via github.
> To make it easier to inspect the actual moving parts, I attached a script which uses `meld` (you'll need to `sudo apt install meld`) to show the diff.
> <img width="1714" height="488" alt="image" src="https://github.com/user-attachments/assets/c0de0c10-bc3d-42d0-84ae-093f18542e9c" />
> This will show you the diff between the original `ethercat_driver.cpp` to the new place where the code was moved.
> The white parts are the same - so moved code. Blue and green are where changes happened - when it looks like lots of changes in one diff, it's largely because that part has moved to the other file (e.g. xml parser). This is also not perfect, but at least a bit better.
>
> Script: just run from the repo root folder. [meld_diff.sh](https://github.com/user-attachments/files/28139994/meld_diff.sh)


## Logic changes beyond just code moving

Beyond moving code and necessities (naming, splitting to different functions) this PR adds the following minimal changes to the logic.

Everything else in the diff is API shape required by the extraction (touched on in next section below), not a behavior change.

### Bug fix: propagate errors

`activateBus()` propagates errors from `setupMaster()` and `configNetwork()`. The pre-refactor `on_activate()` called
  both but ignored their return values; if `master_id` or `control_frequency` parsing failed it logged FATAL and then
  segfaulted in `master_->activate()` on a null pointer. The new code returns failure as `CallbackReturn::ERROR`.

###  Guard: rejection of double bus activation

`configureModules()` rejects re-entry when the bus is active. If called while `activated_` is true, it logs FATAL and returns false rather than clearing the internal state (if we want to add this feature later, we'll have to make sure the state is really properly cleaned, including going through `stop`). When using ros2_control this should never be hit because `on_init` is only called once.

### Minor bug fix: empty transfer/fsoe config

Empty `transfer_config / fsoe_config` values now fail earlier with `CallbackReturn::ERROR`. Before: the key being present triggered transfer loading, then an empty path would fail later in `YAML::LoadFile`. Providing both `transfer_config` and `fsoe_config` now also fails via the early config conversion path (at the top of `on_init`). Previously it failed later, inside `loadTransferConfigYamlFile()`.

## Other (not real behavioral) changes

### activation defaults to false
`activated_` is now initialized to false in `EthercatBusManager` (`EthercatDriver::activated_` was a raw with no initializer)

### New result type

`read() / write()` now return a typed `EthercatCycleResult` (`kCompleted / kSkippedInactive / kSkippedBusy / kError`). The driver wrapper translates everything except `kError` to `return_type::OK`, preserving the original semantics. Nothing returns `kError` today, so the actual behavior is unchanged.  The enum exists for future error paths.

###  API decoupling from ros2_control

Bus configuration is a typed `EthercatBusConfig` struct (master_id, control_frequency, transfer_config, fsoe_config) rather than a `std::unordered_map<std::string,std::string>` of ros2_control hardware parameters. `EthercatDriver::on_init` translates `info_.hardware_parameters` into the struct before handing it to the manager. This allows for different structure of input (e.g. from a differently structured URDF/yaml).

`ConfiguredEcModule` field renames: `state_interface → input_values`, `command_interface → output_values`. Removes
ros2_control vocabulary from the manager's public data type to avoid confusion.

###  Logging

Logger channel renamed from "EthercatDriver" to "EthercatBusManager" for every call inside the bus manager.

###  Unused code removal

`configTransferNetwork()` no-op method deleted. It had an empty body in the pre-refactor code; transfer-net  registration is now done inline in activateBus().

###  Test removal

`TestHelperEthercatSafetyDriver` subclass deleted (`testHelper_ethercat_safety_driver.hpp`) as it wasn't needed any more: those methods are now pulbis on `EthercatBusManager`. The three tests now instantiate `ethercat_driver::EthercatBusManager` driver; and call `driver.getEcTransferModuleParam(...) / driver.getEcTransferNets(...)` directly. No actual runtime behavior change.


# Test plan

--------------

Run the unit tests!

> [!IMPORTANT]
> I used IgH `ethercat` branch `stable-1.6` for testing

```bash
colcon build --symlink-install --packages-up-to ethercat_driver
colcon test --packages-select ethercat_driver --event-handlers console_direct+
```
Expected: 9/9 tests pass

Then, test on the real HW :robot: - just check that no regression happened (this is a code moving PR so it should be OK, but please do verify)
