### PR TITLE
Release master in destructor

### DIFF
--- a/ethercat_interface/src/ec_master.cpp
+++ b/ethercat_interface/src/ec_master.cpp
@@ -75,6 +75,11 @@ EcMaster::~EcMaster()
       delete domain.second;
     }
   }
+  // Release the master obtained in the constructor.
+  if (master_ != NULL) {
+    ecrt_release_master(master_);
+    master_ = NULL;
+  }
 }
 
 void EcMaster::addSlave(uint16_t alias, uint16_t position, EcSlave * slave)


### PR DESCRIPTION
# EcMaster: release the master in the destructor

`EcMaster` requests the master in its constructor (`ecrt_request_master`) but never releases it. The destructor `~EcMaster()` frees only its domains and `stop()` just clears a flag. This means, that the master stays reserved for the whole process lifetime instead of the object's.

A practical consequence of this can be seen  in a ros2_control hardware interface. If an `EcMaster` is destroyed and a new one constructed — e.g. a ros2_control hardware interface going `active --> unconfigured --> configured`, which tears down and rebuilds the bus — the second `ecrt_request_master()` fails because the first handle is still held. The failure is quiet: the constructor only logs `Failed to obtain master.` and leaves `master_` null, so it surfaces later as a failed activation. A plain request-and-exit lifecycle hides it, since the kernel frees the handle on process exit.

## Fix

Add the matching `ecrt_release_master()` to the destructor:

```cpp
EcMaster::~EcMaster()
{
  for (auto & domain : domain_info_) {
    if (domain.second != NULL) { delete domain.second; }
  }
  if (master_ != NULL) {
    ecrt_release_master(master_);
    master_ = NULL;
  }
}
```

No behaviour change for the common path — the master is just freed with the object, so re-acquisition in the same process works.

## Verifying

With the master started (no slaves needed), construct and destroy an `EcMaster`, then keep the process alive:

```cpp
{ ethercat_interface::EcMaster m(0); }
std::this_thread::sleep_for(std::chrono::seconds(10));
```

While it idles, `lsmod | grep ec_master` shows a non-zero use count **before** the fix (the destroyed object still pins the master; `ethercat stop` reports it in use) and zero **after**.
