### PR TITLE
default value related issues

### DIFF
--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -41,10 +41,11 @@ void EcCiA402Drive::updateState()
       );
     }
   }
+  initialized_ = ((state_ == STATE_OPERATION_ENABLED) &&
+    (last_state_ == STATE_OPERATION_ENABLED)) ? true : false;
   last_status_word_ = status_word_;
   last_state_ = state_;
   counter_++;
-  initialized_ = is_operational_;
 }
 
 void EcCiA402Drive::processData(size_t entry_idx, uint8_t * domain_address)

--- a/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
+++ b/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
@@ -318,8 +318,8 @@ bool CLASSM::load_from_config(YAML::Node channel_config)
         id = add_data_without_interface();
       }
 
-      if (map["default_value"]) {
-        v_data[id].default_value = map["default_value"].as<double>();
+      if (map["default"]) {
+        v_data[id].default_value = map["default"].as<double>();
       } else {
         if (RPDO == pdo_type) {
           char ec_addr[16];

--- a/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
+++ b/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
@@ -417,12 +417,8 @@ void CLASSM::ec_write(uint8_t * domain_address, double value, size_t i)
     d.last_value = d.factor * value + d.offset;
     write_functions_[i](domain_address + d.addr_offset, d.last_value, d.mask);
   } else {
-    if (!std::isnan(d.default_value)) {
-      d.last_value = d.default_value;
-      write_functions_[i](domain_address + d.addr_offset, d.last_value, d.mask);
-    } else {  // Do nothing
-      return;
-    }
+    d.last_value = d.default_value;
+    write_functions_[i](domain_address + d.addr_offset, d.last_value, d.mask);
   }
 }
 
@@ -435,7 +431,7 @@ void CLASSM::ec_write_from_interface(uint8_t * domain_address)
       ec_write(domain_address, value, idx);
     } else {
       auto & d = v_data[idx];
-      if ( (RPDO == pdo_type) && allow_ec_write && !std::isnan(d.default_value)) {
+      if (RPDO == pdo_type && allow_ec_write) {
         d.last_value = d.default_value;
         write_functions_[idx](domain_address + d.addr_offset, d.last_value, d.mask);
       }

--- a/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
+++ b/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
@@ -320,6 +320,15 @@ bool CLASSM::load_from_config(YAML::Node channel_config)
 
       if (map["default_value"]) {
         v_data[id].default_value = map["default_value"].as<double>();
+      } else {
+        if (RPDO == pdo_type) {
+          char ec_addr[16];
+          std::snprintf(ec_addr, sizeof(ec_addr), "0x%04X:%02i", index, sub_index);
+          std::string msg = "channel: " + std::string(ec_addr) +
+            " addr_offset: " + std::to_string(v_data[id].addr_offset) +
+            "' has no default value, it is mandatory for RPDO entries";
+          throw std::runtime_error(msg);
+        }
       }
 
       if (map["addr_offset"]) {

--- a/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
+++ b/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
@@ -404,6 +404,9 @@ void CLASSM::ec_read_to_interface(uint8_t * domain_address)
 {
   for (size_t i = 0; i < managed_.size(); ++i) {
     const size_t idx = managed_[i];
+    if (TPDO != pdo_type) {
+      continue;
+    }
     ec_read(domain_address, idx);
     if (is_state_interface_defined(idx) ) {
       state_interface_ptr_->at(interface_ids_[idx]) = v_data[idx].last_value;

--- a/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
+++ b/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
@@ -333,6 +333,12 @@ bool CLASSM::load_from_config(YAML::Node channel_config)
 
       if (map["addr_offset"]) {
         v_data[id].addr_offset = map["addr_offset"].as<size_t>();
+      } else {
+        char ec_addr[16];
+        std::snprintf(ec_addr, sizeof(ec_addr), "0x%04X:%02i", index, sub_index);
+        std::string msg = "channel: " + std::string(ec_addr) +
+          "' has no addr_offset, it is mandatory on data_mapping entries";
+        throw std::runtime_error(msg);
       }
       if (map["type"]) {
         data_type = map["type"].as<std::string>();

--- a/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
+++ b/ethercat_interface/src/ec_pdo_group_interface_channel_manager.cpp
@@ -307,9 +307,6 @@ bool CLASSM::load_from_config(YAML::Node channel_config)
       if (map["command_interface"]) {
         auto command_interface_name = map["command_interface"].as<std::string>();
         id = add_command_interface(command_interface_name);
-        if (map["default_value"]) {
-          v_data[id].default_value = map["default_value"].as<double>();
-        }
       }
 
       if (map["state_interface"]) {
@@ -319,6 +316,10 @@ bool CLASSM::load_from_config(YAML::Node channel_config)
 
       if (std::numeric_limits<size_t>::max() == id) {
         id = add_data_without_interface();
+      }
+
+      if (map["default_value"]) {
+        v_data[id].default_value = map["default_value"].as<double>();
       }
 
       if (map["addr_offset"]) {

--- a/ethercat_interface/src/ec_pdo_single_interface_channel_manager.cpp
+++ b/ethercat_interface/src/ec_pdo_single_interface_channel_manager.cpp
@@ -156,6 +156,9 @@ double CLASSM::ec_read(uint8_t * domain_address, size_t /*i*/)
 
 void CLASSM::ec_read_to_interface(uint8_t * domain_address)
 {
+  if (TPDO != pdo_type) {
+    return;
+  }
   ec_read(domain_address);
   if (is_state_interface_defined() ) {
     state_interface_ptr_->at(state_interface_index_) = last_value;

--- a/ethercat_interface/src/ec_pdo_single_interface_channel_manager.cpp
+++ b/ethercat_interface/src/ec_pdo_single_interface_channel_manager.cpp
@@ -98,10 +98,10 @@ bool CLASSM::load_from_config(YAML::Node channel_config)
     auto command_interface_name = channel_config["command_interface"].as<std::string>();
     command_interface_name_idx_ = all_command_interface_names.size();
     all_command_interface_names.push_back(command_interface_name);
-    // default value
-    if (channel_config["default"]) {
-      default_value = channel_config["default"].as<double>();
-    }
+  }
+
+  if (channel_config["default"]) {
+    default_value = channel_config["default"].as<double>();
   }
 
   if (channel_config["state_interface"]) {

--- a/ethercat_interface/src/ec_pdo_single_interface_channel_manager.cpp
+++ b/ethercat_interface/src/ec_pdo_single_interface_channel_manager.cpp
@@ -171,12 +171,8 @@ void CLASSM::ec_write(uint8_t * domain_address, double value, size_t /*i*/)
     last_value = factor * value + offset;
     write_function_(domain_address, last_value, mask);
   } else {
-    if (!std::isnan(default_value)) {
-      last_value = default_value;
-      write_function_(domain_address, last_value, mask);
-    } else {  // Do nothing
-      return;
-    }
+    last_value = default_value;
+    write_function_(domain_address, last_value, mask);
   }
 }
 
@@ -186,7 +182,7 @@ void CLASSM::ec_write_from_interface(uint8_t * domain_address)
     const auto value = command_interface_ptr_->at(command_interface_index_);
     ec_write(domain_address, value);
   } else {
-    if ( (RPDO == pdo_type) && allow_ec_write && !std::isnan(default_value)) {
+    if (RPDO == pdo_type && allow_ec_write) {
       last_value = default_value;
       write_function_(domain_address, last_value, mask);
     }

--- a/ethercat_interface/src/ec_pdo_single_interface_channel_manager.cpp
+++ b/ethercat_interface/src/ec_pdo_single_interface_channel_manager.cpp
@@ -102,6 +102,14 @@ bool CLASSM::load_from_config(YAML::Node channel_config)
 
   if (channel_config["default"]) {
     default_value = channel_config["default"].as<double>();
+  } else {
+    if (RPDO == pdo_type) {
+      char ec_addr[16];
+      std::snprintf(ec_addr, sizeof(ec_addr), "0x%04X:%02i", index, sub_index);
+      std::string msg = "channel: " + std::string(ec_addr) +
+        "' has no default value, it is mandatory for RPDO entries";
+      throw std::runtime_error(msg);
+    }
   }
 
   if (channel_config["state_interface"]) {

--- a/ethercat_interface/test/test_ec_pdo_channel_manager.cpp
+++ b/ethercat_interface/test/test_ec_pdo_channel_manager.cpp
@@ -63,7 +63,7 @@ TEST(TestEcPdoSingleInterfaceChannelManager, EcReadWriteBit2)
 {
   const char channel_config[] =
     R"(
-      {index: 0x6071, sub_index: 0, type: bit2, mask: 3}
+      {index: 0x6071, sub_index: 9, type: bit2, mask: 3, default: 0}
     )";
   YAML::Node config = YAML::Load(channel_config);
   ethercat_interface::EcPdoSingleInterfaceChannelManager pdo_manager;
@@ -95,7 +95,7 @@ TEST(TestEcPdoSingleInterfaceChannelManager, EcReadWriteBoolMask1)
 {
   const char channel_config[] =
     R"(
-      {index: 0x6071, sub_index: 0, type: bool, mask: 1}
+      {index: 0x6071, sub_index: 0, type: bool, mask: 1, default: 0}
     )";
   YAML::Node config = YAML::Load(channel_config);
   ethercat_interface::EcPdoSingleInterfaceChannelManager pdo_manager;
@@ -122,7 +122,7 @@ TEST(TestEcPdoSingleInterfaceChannelManager, EcReadWriteBit8Mask5)
 {
   const char channel_config[] =
     R"(
-      {index: 0x6071, sub_index: 0, type: bit8, mask: 5}
+      {index: 0x6071, sub_index: 0, type: bit8, mask: 5, default: 0}
     )";
   YAML::Node config = YAML::Load(channel_config);
   ethercat_interface::EcPdoSingleInterfaceChannelManager pdo_manager;
@@ -167,12 +167,12 @@ TEST(TestEcPdoSingleInterfaceChannelManager, EcReadWriteBoolMask5)
 {
   const char channel_config[] =
     R"(
-      {index: 0x6071, sub_index: 0, type: bool, mask: 5}
+      {index: 0x6071, sub_index: 0, type: bool, mask: 16, default: 0}
     )";
   YAML::Node config = YAML::Load(channel_config);
   ethercat_interface::EcPdoSingleInterfaceChannelManager pdo_manager;
   pdo_manager.pdo_type = ethercat_interface::PdoType::RPDO;
-  ASSERT_EQ(pdo_manager.load_from_config(config), false);
+  ASSERT_EQ(pdo_manager.load_from_config(config), true);
 
   return;
   // ASSERT_EQ(pdo_manager.data_type(), "bool");
@@ -220,6 +220,7 @@ TEST(TestEcPdoGroupInterfaceChannelManager, LoadConfigTest)
             type: int32,
             factor: 3.14,
             offset: 2.71,
+            default: 0,
             command_interface: effort
           },
           {
@@ -227,17 +228,21 @@ TEST(TestEcPdoGroupInterfaceChannelManager, LoadConfigTest)
             type: int16,
             factor: 1.1,
             offset: 0.1,
-            state_interface: position
+            default: 0,
+            command_interface: position
           },
           {
             addr_offset: 66,
             type: uint8,
-            mask: 7,
+            default: 0,
+            command_interface: controlword
           },
           {
             addr_offset: 67,
             type: bool,
             mask: 8,
+            default: 0,
+            command_interface: enable
           }
         ]
       }
@@ -248,7 +253,7 @@ TEST(TestEcPdoGroupInterfaceChannelManager, LoadConfigTest)
   ASSERT_EQ(pdo_manager.load_from_config(config), true);
 
   ASSERT_EQ(pdo_manager.number_of_interfaces(), 5);
-  ASSERT_EQ(pdo_manager.number_of_managed_interfaces(), 2);
+  ASSERT_EQ(pdo_manager.number_of_managed_interfaces(), 4);
 
   ASSERT_EQ(pdo_manager.data_type(0), "bit240");
   ASSERT_EQ(pdo_manager.interface_name(0), "null");
@@ -268,12 +273,12 @@ TEST(TestEcPdoGroupInterfaceChannelManager, LoadConfigTest)
   ASSERT_EQ(pdo_manager.v_data[2].addr_offset, 64);
 
   ASSERT_EQ(pdo_manager.data_type(3), "uint8");
-  ASSERT_EQ(pdo_manager.interface_name(3), "null");
-  ASSERT_EQ(pdo_manager.data(3).mask, 7);
+  ASSERT_EQ(pdo_manager.interface_name(3), "controlword");
   ASSERT_EQ(pdo_manager.v_data[3].addr_offset, 66);
 
   ASSERT_EQ(pdo_manager.data_type(4), "bool");
-  ASSERT_EQ(pdo_manager.interface_name(4), "null");
+  ASSERT_EQ(pdo_manager.interface_name(4), "enable");
+  ASSERT_EQ(pdo_manager.v_data[4].addr_offset, 67);
   ASSERT_EQ(pdo_manager.data(4).mask, 8);
 }
 
@@ -286,36 +291,28 @@ TEST(TestEcPdoGroupInterfaceChannelManager, ReadWriteBits)
         index: 0x6071,
         sub_index: 0x00,
         type: bit8,
+        default: 0,
         data_mapping: [
           {
             type: bool,
             mask: 1,
-            command_interface: input1
+            default: 0,
+            addr_offset: 0,
+            command_interface: output1
           },
           {
             type: bool,
             mask: 2,
-            state_interface: output1
+            default: 0,
+            addr_offset: 0,
+            command_interface: output2
           },
           {
             type: bool,
             mask: 4,
-            command_interface: input2
-          },
-          {
-            type: bool,
-            mask: 8,
-            state_interface: output2
-          },
-          {
-            type: bool,
-            mask: 16,
-            command_interface: input3
-          },
-          {
-            type: bool,
-            mask: 32,
-            state_interface: output3
+            default: 0,
+            addr_offset: 0,
+            command_interface: output3
           }
         ]
       }
@@ -325,8 +322,8 @@ TEST(TestEcPdoGroupInterfaceChannelManager, ReadWriteBits)
   pdo_manager.pdo_type = ethercat_interface::PdoType::RPDO;
   ASSERT_EQ(pdo_manager.load_from_config(config), true);
 
-  ASSERT_EQ(pdo_manager.number_of_interfaces(), 7);
-  ASSERT_EQ(pdo_manager.number_of_managed_interfaces(), 6);
+  ASSERT_EQ(pdo_manager.number_of_interfaces(), 4);
+  ASSERT_EQ(pdo_manager.number_of_managed_interfaces(), 3);
 
   ASSERT_EQ(pdo_manager.data_type(0), "bit8");
   ASSERT_EQ(pdo_manager.interface_name(0), "null");
@@ -334,45 +331,29 @@ TEST(TestEcPdoGroupInterfaceChannelManager, ReadWriteBits)
   ASSERT_EQ(pdo_manager.sub_index, 0);
 
   ASSERT_EQ(pdo_manager.data_type(1), "bool");
-  ASSERT_EQ(pdo_manager.interface_name(1), "input1");
+  ASSERT_EQ(pdo_manager.interface_name(1), "output1");
   ASSERT_EQ(pdo_manager.data(1).mask, 1);
   ASSERT_EQ(pdo_manager.v_data[1].addr_offset, 0);
 
   ASSERT_EQ(pdo_manager.data_type(2), "bool");
-  ASSERT_EQ(pdo_manager.interface_name(2), "output1");
+  ASSERT_EQ(pdo_manager.interface_name(2), "output2");
   ASSERT_EQ(pdo_manager.data(2).mask, 2);
   ASSERT_EQ(pdo_manager.v_data[2].addr_offset, 0);
 
   ASSERT_EQ(pdo_manager.data_type(3), "bool");
-  ASSERT_EQ(pdo_manager.interface_name(3), "input2");
+  ASSERT_EQ(pdo_manager.interface_name(3), "output3");
   ASSERT_EQ(pdo_manager.data(3).mask, 4);
   ASSERT_EQ(pdo_manager.v_data[3].addr_offset, 0);
-
-  ASSERT_EQ(pdo_manager.data_type(4), "bool");
-  ASSERT_EQ(pdo_manager.interface_name(4), "output2");
-  ASSERT_EQ(pdo_manager.data(4).mask, 8);
-  ASSERT_EQ(pdo_manager.v_data[4].addr_offset, 0);
-
-  ASSERT_EQ(pdo_manager.data_type(5), "bool");
-  ASSERT_EQ(pdo_manager.interface_name(5), "input3");
-  ASSERT_EQ(pdo_manager.data(5).mask, 16);
-  ASSERT_EQ(pdo_manager.v_data[5].addr_offset, 0);
-
-  ASSERT_EQ(pdo_manager.data_type(6), "bool");
-  ASSERT_EQ(pdo_manager.interface_name(6), "output3");
-  ASSERT_EQ(pdo_manager.data(6).mask, 32);
-  ASSERT_EQ(pdo_manager.v_data[6].addr_offset, 0);
 
   uint8_t buffer[1];
   std::vector<uint8_t> write_tests0 =
   {
-    0, 1, 2, 4, 8, 16, 32,
-    0b00111111,
-    0b11000000,
-    0b11111111,
-    0b00101010,
-    0b11010101,
-    0b00001111
+    0, 1, 2, 4,
+    0b00000111,
+    0b00000000,
+    0b00000010,
+    0b00000101,
+    0b00000111
   };
 
   for (size_t n = 0; n < write_tests0.size(); ++n) {
@@ -380,7 +361,7 @@ TEST(TestEcPdoGroupInterfaceChannelManager, ReadWriteBits)
     ASSERT_EQ(pdo_manager.ec_read(buffer), write_tests0[n]);
 
     std::bitset<8> bits(write_tests0[n]);
-    for (size_t i = 1; i < 7; i++) {
+    for (size_t i = 1; i < 3; i++) {
       ASSERT_EQ(pdo_manager.ec_read(buffer, i), bits.test(i - 1));
     }
   }


### PR DESCRIPTION
These are commits related to how the  default value is handled

Additionally, there is a commit for cia402 driver that reverts the initialized check to what is was before 65ba86f
and a commit making 'addr_offset' mandatory for groupped PDOs as it does not make sense to have  groupped PDOs without offset.

I can split into 3 PR's if that makes sense, let me know

note: this PR is locally build on top of #182 