### PR TITLE
Search standard system paths for EtherCAT master before /usr/local/etherlab

### DIFF
--- a/ethercat_interface/CMakeLists.txt
+++ b/ethercat_interface/CMakeLists.txt
@@ -18,14 +18,21 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 
 # EtherLab
-set(ETHERLAB_DIR /usr/local/etherlab)
+set(ETHERLAB_LOCAL_DIR /usr/local/etherlab)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-find_library(ETHERCAT_LIB ethercat HINTS ${ETHERLAB_DIR}/lib)
+find_path(ETHERCAT_INCLUDE_DIR NAMES ecrt.h PATHS ${ETHERLAB_LOCAL_DIR}/include)
+find_library(ETHERCAT_LIB NAMES ethercat PATHS ${ETHERLAB_LOCAL_DIR}/lib)
+
+if(NOT ETHERCAT_INCLUDE_DIR OR NOT ETHERCAT_LIB)
+  message(FATAL_ERROR
+    "Could not find the IgH EtherCAT master (ecrt.h / libethercat). "
+    "Looked in standard system paths and in ${ETHERLAB_LOCAL_DIR}.")
+endif()
 
 ament_export_include_directories(
   include
-  ${ETHERLAB_DIR}/include
+  ${ETHERCAT_INCLUDE_DIR}
 )
 
 add_library(
@@ -41,7 +48,7 @@ target_include_directories(
   ${PROJECT_NAME}
   PRIVATE
   include
-  ${ETHERLAB_DIR}/include
+  ${ETHERCAT_INCLUDE_DIR}
 )
 
 target_link_libraries(${PROJECT_NAME} ${ETHERCAT_LIB})
@@ -75,7 +82,7 @@ if(BUILD_TESTING)
     test_ec_pdo_channel_manager
     test/test_ec_pdo_channel_manager.cpp
   )
-  target_include_directories(test_ec_pdo_channel_manager PRIVATE include ${ETHERLAB_DIR}/include)
+  target_include_directories(test_ec_pdo_channel_manager PRIVATE include ${ETHERCAT_INCLUDE_DIR})
 
   target_link_libraries(test_ec_pdo_channel_manager
     ${PROJECT_NAME}

--- a/ethercat_manager/CMakeLists.txt
+++ b/ethercat_manager/CMakeLists.txt
@@ -12,14 +12,21 @@ find_package(rclcpp REQUIRED)
 find_package(ethercat_msgs REQUIRED)
 
 # EtherLab
-set(ETHERLAB_DIR /usr/local/etherlab)
+set(ETHERLAB_LOCAL_DIR /usr/local/etherlab)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-find_library(ETHERCAT_LIB ethercat HINTS ${ETHERLAB_DIR}/lib)
+find_path(ETHERCAT_INCLUDE_DIR NAMES ecrt.h PATHS ${ETHERLAB_LOCAL_DIR}/include)
+find_library(ETHERCAT_LIB NAMES ethercat PATHS ${ETHERLAB_LOCAL_DIR}/lib)
+
+if(NOT ETHERCAT_INCLUDE_DIR OR NOT ETHERCAT_LIB)
+  message(FATAL_ERROR
+    "Could not find the IgH EtherCAT master (ecrt.h / libethercat). "
+    "Looked in standard system paths and in ${ETHERLAB_LOCAL_DIR}.")
+endif()
 
 ament_export_include_directories(
   include
-  ${ETHERLAB_DIR}/include
+  ${ETHERCAT_INCLUDE_DIR}
 )
 
 add_executable(
@@ -29,7 +36,7 @@ target_include_directories(
   ethercat_sdo_srv_server
   PRIVATE
   include
-  ${ETHERLAB_DIR}/include
+  ${ETHERCAT_INCLUDE_DIR}
 )
 target_link_libraries(ethercat_sdo_srv_server ${ETHERCAT_LIB})
 ament_target_dependencies(ethercat_sdo_srv_server rclcpp ethercat_msgs)


### PR DESCRIPTION
Previously the include/lib paths were hardcoded to /usr/local/etherlab, which broke the build when the IgH EtherCAT master was installed via the distro package (headers/libs in the usual system locations). Now find_path/find_library check standard system paths first and fall back to /usr/local/etherlab, with a clear error if neither has it.